### PR TITLE
Opportunistic PVH dom0 upgrade (dom0=pvh-auto)

### DIFF
--- a/xen/arch/x86/dom0_build.c
+++ b/xen/arch/x86/dom0_build.c
@@ -268,15 +268,24 @@ bool __initdata opt_dom0_shadow;
 bool __initdata opt_dom0_pvh = !IS_ENABLED(CONFIG_PV);
 bool __initdata opt_dom0_verbose = IS_ENABLED(CONFIG_VERBOSE_DEBUG);
 bool __initdata opt_dom0_msr_relaxed;
+bool __initdata opt_dom0_pvh_auto = false;
 
 int __init parse_arch_dom0_param(const char *s, const char *e)
 {
     int val;
 
     if ( IS_ENABLED(CONFIG_PV) && !cmdline_strcmp(s, "pv") )
+    {
+        opt_dom0_pvh_auto = false;
         opt_dom0_pvh = false;
+    }
     else if ( IS_ENABLED(CONFIG_HVM) && !cmdline_strcmp(s, "pvh") )
+    {
+        opt_dom0_pvh_auto = false;
         opt_dom0_pvh = true;
+    }
+    else if ( !cmdline_strcmp(s, "pvh-auto") )
+        opt_dom0_pvh_auto = true;
 #ifdef CONFIG_SHADOW_PAGING
     else if ( (val = parse_boolean("shadow", s, e)) >= 0 )
         opt_dom0_shadow = val;

--- a/xen/arch/x86/include/asm/setup.h
+++ b/xen/arch/x86/include/asm/setup.h
@@ -67,6 +67,7 @@ extern bool opt_dom0_pvh;
 extern bool opt_dom0_verbose;
 extern bool opt_dom0_cpuid_faulting;
 extern bool opt_dom0_msr_relaxed;
+extern bool opt_dom0_pvh_auto;
 
 #define max_init_domid (0)
 

--- a/xen/arch/x86/setup.c
+++ b/xen/arch/x86/setup.c
@@ -2170,6 +2170,20 @@ void asmlinkage __init noreturn __start_xen(void)
     }
 
     /*
+     * We now know enough to determine whether or not we should use PVH, so
+     * opportunistically upgrade if dom0=pvh-auto has been provided on the
+     * Xen command-line.
+     */
+    if ( opt_dom0_pvh_auto )
+    {
+        opt_dom0_pvh = iommu_enabled && hvm_enabled;
+
+        if ( !opt_dom0_pvh )
+            printk(XENLOG_WARNING "Unable to use PVH mode (iommu: %d, hvm: %d)\n",
+                   iommu_enabled, hvm_enabled);
+    }
+
+    /*
      * We're going to setup domain0 using the module(s) that we stashed safely
      * above our heap. The second module, if present, is an initrd ramdisk.
      */


### PR DESCRIPTION
This PR adds support for `dom0=pvh-auto`, which will prefer using the PVH dom0 boot protocol instead of the traditional PV boot protocol when the underlying prerequisite capabilities (HVM, IOMMU) are present.