### PR TITLE
Fix static builds with 4.21

### DIFF
--- a/tools/ocaml/Makefile.rules
+++ b/tools/ocaml/Makefile.rules
@@ -80,8 +80,10 @@ endef
 # Dynamically linked OCaml libraries ("plugins" in Dynlink parlance)
 # need to compile an .cmxs file
 define OCAML_DYN_LIBRARY_template
+ifneq ($(nosharedlibs),y)
  $(1).cmxs: $(1).cmxa
 	$(call mk-caml-shared-lib-native,$$@, $(1).cmxa)
+endif
  $(1).cmxa: lib$(1)_stubs.a $(foreach obj,$($(1)_OBJS),$(obj).cmx)
 	$(call mk-caml-lib-native,$$@, -cclib -l$(1)_stubs $(foreach lib,$(LIBS_$(1)),-cclib $(lib)), $(foreach obj,$($(1)_OBJS),$(obj).cmx))
  $(1)_stubs.a: $(foreach obj,$$($(1)_C_OBJS),$(obj).o)

--- a/tools/ocaml/libs/xsd_glue/domain_getinfo_plugin_v1/Makefile
+++ b/tools/ocaml/libs/xsd_glue/domain_getinfo_plugin_v1/Makefile
@@ -9,7 +9,10 @@ OCAMLINCLUDE += -I ./ -I ../
 
 OBJS = domain_getinfo_v1
 INTF = $(foreach obj, $(OBJS),$(obj).cmi)
-LIBS = domain_getinfo_v1.cmxa domain_getinfo_v1.cmxs
+LIBS = domain_getinfo_v1.cmxa
+ifneq ($(nosharedlibs),y)
+LIBS += domain_getinfo_v1.cmxs
+endif
 
 LIBS_xsd_glue = $(call xenlibs-ldflags-ldlibs,xenctrl)
 

--- a/tools/ocaml/xenstored/Makefile
+++ b/tools/ocaml/xenstored/Makefile
@@ -71,7 +71,12 @@ XENSTOREDLIBS = \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xb $(OCAML_TOPLEVEL)/libs/xb/xenbus.cmxa \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xsd_glue $(OCAML_TOPLEVEL)/libs/xsd_glue/plugin_interface_v1.cmxa \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xsd_glue/domain_getinfo_plugin_v1 $(OCAML_TOPLEVEL)/libs/xsd_glue/domain_getinfo_plugin_v1/domain_getinfo_v1.cmxa \
-	-ccopt -L -ccopt $(XEN_ROOT)/tools/libs/ctrl
+	-ccopt -L -ccopt $(XEN_ROOT)/tools/libs/ctrl \
+	-cclib $(XEN_ROOT)/tools/libs/call/libxencall.a \
+	-cclib $(XEN_ROOT)/tools/libs/foreignmemory/libxenforeignmemory.a \
+	-cclib $(XEN_ROOT)/tools/libs/devicemodel/libxendevicemodel.a \
+	-cclib $(XEN_ROOT)/tools/libs/toolcore/libxentoolcore.a \
+	-cclib $(XEN_ROOT)/tools/libs/toollog/libxentoollog.a
 
 PROGRAMS = oxenstored
 

--- a/tools/ocaml/xenstored/Makefile
+++ b/tools/ocaml/xenstored/Makefile
@@ -70,6 +70,7 @@ XENSTOREDLIBS = \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xc $(OCAML_TOPLEVEL)/libs/xc/xenctrl.cmxa \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xb $(OCAML_TOPLEVEL)/libs/xb/xenbus.cmxa \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xsd_glue $(OCAML_TOPLEVEL)/libs/xsd_glue/plugin_interface_v1.cmxa \
+	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xsd_glue/domain_getinfo_plugin_v1 $(OCAML_TOPLEVEL)/libs/xsd_glue/domain_getinfo_plugin_v1/domain_getinfo_v1.cmxa \
 	-ccopt -L -ccopt $(XEN_ROOT)/tools/libs/ctrl
 
 PROGRAMS = oxenstored

--- a/tools/ocaml/xenstored/domains.ml
+++ b/tools/ocaml/xenstored/domains.ml
@@ -35,12 +35,16 @@ let load_plug fname =
 let () =
   let plugins_dir = Paths.libexec ^ "/ocaml/xsd_glue/xenctrl_plugin/" in
   let filepath = plugins_dir ^ "domain_getinfo_v1.cmxs" in
-  debug "Trying to load plugin '%s'\n%!" filepath;
-  let list_files = Sys.readdir plugins_dir in
-  debug "Directory listing of '%s'\n%!" plugins_dir ;
-  Array.iter (fun x -> debug "\t%s\n%!" x) list_files;
-  Dynlink.allow_only [ "Plugin_interface_v1" ];
-  load_plug filepath
+  if Sys.file_exists filepath then begin
+    debug "Trying to load plugin '%s'\n%!" filepath;
+    let list_files = Sys.readdir plugins_dir in
+    debug "Directory listing of '%s'\n%!" plugins_dir ;
+    Array.iter (fun x -> debug "\t%s\n%!" x) list_files;
+    Dynlink.allow_only [ "Plugin_interface_v1" ];
+    load_plug filepath
+  end else begin
+    debug "Plugin file '%s' not found, assuming statically linked\n%!" filepath
+  end
 
 module Plugin =
   (val Plugin_interface_v1.get_plugin_v1 ()


### PR DESCRIPTION
This does 2 things:

1. Now that this is built off of feature branches, just commit https://github.com/edera-dev/xen-oci/blob/main/patches/4.20.0/oxenstored/dependencies.patch directly to the `edera/4.21` branch rather than keep it as a patch (I can revert this if we'd rather it stay as a patch, for some reason I missed).

2. Fixes the dynamically-loaded `domain_getinfo_v1.cmxs` plugin, which was previously always built as a shared lib, even for static builds, which broke our static builds. This just changes the makefile to skip it if `nosharedlibs=y`, and to assume it's statically linked rather than trying to dynamically load it.