### PR TITLE
Fix static plugin linking in oxenstored

### DIFF
--- a/tools/ocaml/xenstored/Makefile
+++ b/tools/ocaml/xenstored/Makefile
@@ -18,12 +18,10 @@ OCAMLINCLUDE += \
 	-I $(OCAML_TOPLEVEL)/libs/eventchn \
 	-I $(OCAML_TOPLEVEL)/libs/xsd_glue
 
-LIBS = syslog.cma syslog.cmxa poll.cma poll.cmxa
+LIBS = syslog.cma syslog.cmxa
 syslog_OBJS = syslog
 syslog_C_OBJS = syslog_stubs
-poll_OBJS = poll
-poll_C_OBJS = select_stubs
-OCAML_LIBRARY = syslog poll
+OCAML_LIBRARY = syslog
 
 LIBS += systemd.cma systemd.cmxa
 systemd_OBJS = systemd
@@ -57,26 +55,26 @@ OBJS = paths \
 	poll \
 	xenstored
 
-INTF = symbol.cmi trie.cmi syslog.cmi systemd.cmi poll.cmi
+INTF = symbol.cmi trie.cmi syslog.cmi systemd.cmi
 
 XENSTOREDLIBS = \
 	unix.cmxa \
 	dynlink.cmxa \
 	-ccopt -L -ccopt . syslog.cmxa \
 	-ccopt -L -ccopt . systemd.cmxa \
-	-ccopt -L -ccopt . poll.cmxa \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/mmap $(OCAML_TOPLEVEL)/libs/mmap/xenmmap.cmxa \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/eventchn $(OCAML_TOPLEVEL)/libs/eventchn/xeneventchn.cmxa \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xc $(OCAML_TOPLEVEL)/libs/xc/xenctrl.cmxa \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xb $(OCAML_TOPLEVEL)/libs/xb/xenbus.cmxa \
 	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xsd_glue $(OCAML_TOPLEVEL)/libs/xsd_glue/plugin_interface_v1.cmxa \
-	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xsd_glue/domain_getinfo_plugin_v1 $(OCAML_TOPLEVEL)/libs/xsd_glue/domain_getinfo_plugin_v1/domain_getinfo_v1.cmxa \
+	-ccopt -L -ccopt $(OCAML_TOPLEVEL)/libs/xsd_glue/domain_getinfo_plugin_v1 -linkall $(OCAML_TOPLEVEL)/libs/xsd_glue/domain_getinfo_plugin_v1/domain_getinfo_v1.cmxa \
 	-ccopt -L -ccopt $(XEN_ROOT)/tools/libs/ctrl \
 	-cclib $(XEN_ROOT)/tools/libs/call/libxencall.a \
 	-cclib $(XEN_ROOT)/tools/libs/foreignmemory/libxenforeignmemory.a \
 	-cclib $(XEN_ROOT)/tools/libs/devicemodel/libxendevicemodel.a \
 	-cclib $(XEN_ROOT)/tools/libs/toolcore/libxentoolcore.a \
-	-cclib $(XEN_ROOT)/tools/libs/toollog/libxentoollog.a
+	-cclib $(XEN_ROOT)/tools/libs/toollog/libxentoollog.a \
+	-cclib libselect_stubs.a
 
 PROGRAMS = oxenstored
 
@@ -86,10 +84,14 @@ oxenstored_LIBS = $(XENSTOREDLIBS)
 # dependencies between files
 oxenstored_MLSORTED = $(shell $(OCAMLDEP) -sort $(OBJS:=.ml))
 oxenstored_OBJS = $(oxenstored_MLSORTED:.ml=)
+oxenstored_EXTRA_DEPS = libselect_stubs.a
 
 OCAML_PROGRAM = oxenstored
 
 all: $(INTF) $(LIBS) $(PROGRAMS)
+
+libselect_stubs.a: select_stubs.o
+	$(AR) rc $@ $^
 
 bins: $(PROGRAMS)
 

--- a/tools/ocaml/xenstored/poll.ml
+++ b/tools/ocaml/xenstored/poll.ml
@@ -30,8 +30,10 @@ external set_fd_limit: int -> unit = "stub_set_fd_limit"
 let get_sys_fs_nr_open () =
   try
     let ch = open_in "/proc/sys/fs/nr_open" in
-    let v = Utils.int_of_string_exn (input_line ch) in
-    close_in_noerr ch; v
+    let line = input_line ch in
+    close_in_noerr ch;
+    let trimmed = String.trim line in
+    int_of_string trimmed
   with _ -> 1024 * 1024
 
 let init_event () = {read = false; write = false; except = false}


### PR DESCRIPTION
https://github.com/edera-dev/xen/pull/3 was insufficient

Basically, 

- needed `-linkall` for the plugin to link it statically.
- this affected the `poll` dep, which used to be built as a separate ocaml lib, but is now being statically linked into the binary (so no longer need the `cxma/cmi/cmx` ocaml lib bits)

In general the `oxenstored` makefiles don't seem to be fully compatible with Alpine static builds (due to the introduction of dynamic plugin loading, unless I am missing something obvious) so we might want to fix that upstream eventually.

(this seems to work under gnu static, so this is probably a `musl`-specific thing - I don't know a better way to solve this other than just building the plugins as static libs and linking them in, which is what we do here)