### PR TITLE
x86/cpu: do not attempt to enable DOITM when running as nested hypervisor

### DIFF
--- a/xen/arch/x86/cpu/common.c
+++ b/xen/arch/x86/cpu/common.c
@@ -213,6 +213,13 @@ static void setup_doitm(void)
 {
     uint64_t msr;
 
+    /*
+     * If we are running under another hypervisor, we can't turn on DOITM as the
+     * parent hypervisor will block it.
+     */
+    if ( cpu_has_hypervisor )
+        return;
+
     if ( !cpu_has_doitm )
         return;
 


### PR DESCRIPTION
The parent hypervisor will block the RDMSR/WRMSR requests resulting in Xen crashing with a GPF (fault code 0).