### PR TITLE
xen/vpci: add DOMCTL_vpci_get_devices hypercall

### DIFF
--- a/xen/common/domctl.c
+++ b/xen/common/domctl.c
@@ -827,6 +827,7 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
     case XEN_DOMCTL_test_assign_device:
     case XEN_DOMCTL_deassign_device:
     case XEN_DOMCTL_get_device_group:
+    case XEN_DOMCTL_vpci_get_devices:
         ret = iommu_do_domctl(op, d, u_domctl);
         break;
 

--- a/xen/drivers/passthrough/pci.c
+++ b/xen/drivers/passthrough/pci.c
@@ -1890,6 +1890,56 @@ static bool needs_vpci(const struct domain *d)
     return arch_needs_vpci(d);
 }
 
+#ifdef CONFIG_HAS_VPCI_GUEST_SUPPORT
+static int vpci_get_devices(
+    const struct domain *d,
+    struct xen_domctl *domctl,
+    XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
+{
+    uint32_t count = 0;
+    struct pci_dev *pdev;
+    xen_domctl_vpci_device_t dev;
+    struct xen_domctl_vpci_get_devices *devs = &domctl->u.vpci_get_devices;
+
+    /* only the control domain is allowed to see this information */
+    if ( !is_control_domain(d) )
+        return -EPERM;
+
+    list_for_each_entry(pdev, &d->pdev_list, domain_list)
+    {
+        if ( !pdev->vpci )
+            continue;
+
+        if ( pdev->vpci->guest_sbdf.sbdf == INVALID_GUEST_SBDF.sbdf )
+            continue;
+
+        if ( guest_handle_is_null(devs->devs) )
+        {
+            count++;
+            continue;
+        }
+
+        if ( count >= devs->device_count )
+            return -ENOBUFS;
+
+        dev.host_sbdf  = pdev->sbdf.sbdf;
+        dev.guest_sbdf = pdev->vpci->guest_sbdf.sbdf;
+
+        if ( copy_to_guest_offset(devs->devs, count, &dev, 1) )
+            return -EFAULT;
+
+        count++;
+    }
+
+    if ( __copy_to_guest(u_domctl, domctl, 1) )
+        return -EFAULT;
+
+    devs->device_count = count;
+
+    return 0;
+}
+#endif
+
 int iommu_do_pci_domctl(
     struct xen_domctl *domctl, struct domain *d,
     XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
@@ -2023,6 +2073,14 @@ int iommu_do_pci_domctl(
         ret = deassign_device(d, seg, bus, devfn);
         pcidevs_unlock();
         break;
+
+#ifdef CONFIG_HAS_VPCI_GUEST_SUPPORT
+    case XEN_DOMCTL_vpci_get_devices:
+        pcidevs_lock();
+        ret = vpci_get_devices(d, domctl, u_domctl);
+        pcidevs_unlock();
+        break;
+#endif
 
     default:
         ret = -ENOSYS;

--- a/xen/include/public/domctl.h
+++ b/xen/include/public/domctl.h
@@ -818,6 +818,19 @@ struct xen_domctl_gdbsx_domstatus {
     uint32_t         vcpu_ev;    /* if yes, what event? */
 };
 
+/* XEN_DOMCTL_vpci_get_devices */
+struct xen_domctl_vpci_device {
+    uint32_t host_sbdf;
+    uint32_t guest_sbdf;
+};
+typedef struct xen_domctl_vpci_device xen_domctl_vpci_device_t;
+DEFINE_XEN_GUEST_HANDLE(xen_domctl_vpci_device_t);
+
+struct xen_domctl_vpci_get_devices {
+    uint32_t device_count;                              /* IN/OUT */
+    XEN_GUEST_HANDLE_64(xen_domctl_vpci_device_t) devs; /* IN/OUT */
+};
+
 /*
  * VM event operations
  */
@@ -1374,6 +1387,7 @@ struct xen_domctl {
 #define XEN_DOMCTL_gdbsx_pausevcpu             1001
 #define XEN_DOMCTL_gdbsx_unpausevcpu           1002
 #define XEN_DOMCTL_gdbsx_domstatus             1003
+#define XEN_DOMCTL_vpci_get_devices            2000
     uint32_t interface_version; /* XEN_DOMCTL_INTERFACE_VERSION */
     domid_t  domain;
     uint16_t _pad[3];
@@ -1438,6 +1452,7 @@ struct xen_domctl {
 #endif
         struct xen_domctl_set_llc_colors    set_llc_colors;
         struct xen_domctl_get_domain_state  get_domain_state;
+        struct xen_domctl_vpci_get_devices  vpci_get_devices;
         uint8_t                             pad[128];
     } u;
 };


### PR DESCRIPTION
This hypercall is used to allow dom0 to learn the vPCI mappings for a domain's passthrough devices.

This way the Edera platform can inform the Edera zone agent which physical devices have been attached to which PCI slot inside the zone.

This is presently an Edera-specific hypercall, we should change the ID to something lower before upstreaming it.