### PR TITLE
vNUMA: automatically fix Intel leaf 0xB and AMD leaf 0x80000008 topology

### DIFF
--- a/tools/libs/light/libxl_cpuid.c
+++ b/tools/libs/light/libxl_cpuid.c
@@ -414,13 +414,13 @@ int libxl_cpuid_parse_config(libxl_cpuid_policy_list *policy, const char* str)
 int libxl_cpuid_parse_config_xend(libxl_cpuid_policy_list *policy,
                                   const char* str)
 {
-    char *endptr;
+    const char *endptr;
     unsigned long value;
     uint32_t leaf, subleaf = XEN_CPUID_INPUT_UNUSED;
     struct xc_xend_cpuid *entry;
 
     /* parse the leaf number */
-    value = strtoul(str, &endptr, 0);
+    value = strtoul(str, (char **)&endptr, 0);
     if (str == endptr) {
         return 1;
     }
@@ -428,7 +428,7 @@ int libxl_cpuid_parse_config_xend(libxl_cpuid_policy_list *policy,
     /* check for an optional subleaf number */
     if (*endptr == ',') {
         str = endptr + 1;
-        value = strtoul(str, &endptr, 0);
+        value = strtoul(str, (char **)&endptr, 0);
         if (str == endptr) {
             return 2;
         }

--- a/tools/libs/light/libxl_internal.c
+++ b/tools/libs/light/libxl_internal.c
@@ -204,7 +204,7 @@ char *libxl__strndup(libxl__gc *gc, const char *c, size_t n)
 
 char *libxl__dirname(libxl__gc *gc, const char *s)
 {
-    char *c = strrchr(s, '/');
+    const char *c = strrchr(s, '/');
 
     if (!c)
         return NULL;

--- a/xen/arch/x86/cpu-policy.c
+++ b/xen/arch/x86/cpu-policy.c
@@ -335,6 +335,178 @@ static void recalculate_misc(struct cpu_policy *p)
     }
 }
 
+/*
+ * Recalculate CPUID topology leaves to reflect vNUMA topology when the
+ * domain has a virtual NUMA configuration.  Must be called after
+ * recalculate_misc(), which resets p->topo.raw and clamps p->extd.raw[0x8].c
+ * to its allowed bits.
+ *
+ * Two leaves are fixed here:
+ *
+ * 1. CPUID 0x80000008 ECX (AMD/Hygon only)
+ *    recalculate_misc() zeroes leaf 0x8000001D (TopoExt Cache) entirely, so
+ *    the guest kernel falls back to CPUID 0x80000008 for package topology on
+ *    AMD.  Without this fix, the host NC and ApicIdSize values leak through
+ *    unchanged, encoding the physical package size.  This makes all vCPUs
+ *    appear to be LLC siblings regardless of vNUMA node boundaries, producing
+ *    "topology_sane" WARN_ON splats in the guest at boot.
+ *
+ *    recalculate_misc() preserves ECX bits [17:12] and [7:0] through its
+ *    mask (0x0003f0ff), so our corrected values are not subsequently
+ *    clobbered.  We fix:
+ *      ECX[7:0]   = NC:          logical processors per package, minus 1
+ *      ECX[15:12] = ApicIdSize:  (x2)APIC ID bits encoding core in package
+ *
+ * 2. CPUID 0xB subleaves (all vendors with x2APIC)
+ *    recalculate_misc() unconditionally zeroes p->topo.raw.  With all fields
+ *    zero, the guest kernel sees ECX[15:8]=0 (type=invalid) on subleaf 0 and
+ *    stops enumeration immediately, ignoring the x2APIC IDs in EDX.  We
+ *    populate the structural subleaf fields from vNUMA config; the per-vCPU
+ *    EDX fixup already present in guest_cpuid() case 0xb requires no changes.
+ *
+ * x2APIC IDs are assigned as (vcpu_id * 2) by the dynamic fixup in
+ * guest_cpuid().  Bit 0 is permanently clear — each vCPU is a single-threaded
+ * core with no SMT sibling.  The NUMA-node (package) boundary falls at bit
+ * pkg_shift, where:
+ *
+ *   pkg_shift = 1 (SMT bit) + log2(vcpus_per_node)
+ *
+ * Example with 16 vCPUs per node across 2 vNUMA nodes (32 vCPUs total):
+ *   pkg_shift = 5; IDs 0-30  (vcpu_id  0-15) → package 0 (bit 5 = 0)
+ *               5; IDs 32-62 (vcpu_id 16-31) → package 1 (bit 5 = 1)
+ *
+ * This encoding is only valid when vcpus_per_node is a power of 2 and vCPUs
+ * are assigned to vNUMA nodes in contiguous ascending order (0..N-1 → node 0,
+ * N..2N-1 → node 1, etc.), which is assumed to be the case when the toolstack
+ * calls XEN_DOMCTL_SETVNUMAINFO before XEN_DOMCTL_set_cpu_policy.
+ *
+ * Leaf 0x1F (Extended Topology v2, preferred over 0xB by LLVM OpenMP and
+ * other modern runtimes per Intel SDM Vol. 2A) is not handled here because:
+ *   1. Xen currently caps the guest basic max leaf below 0x1F.
+ *   2. There is no subleaf-indexed backing storage for leaf 0x1F in struct
+ *      cpu_policy (leaf 0xB uses p->topo.raw; no equivalent exists for 0x1F).
+ *   3. guest_cpuid() would need a new case 0x1f: for the per-vCPU EDX fixup.
+ * Supporting leaf 0x1F is deferred until the broader topology rework
+ * referenced by the TODO comments throughout this file.
+ */
+static void recalculate_vnuma_topo(const struct domain *d, struct cpu_policy *p)
+{
+    const struct vnuma_info *vnuma;
+    unsigned int nr_vnodes, vcpus_per_node, pkg_shift;
+
+    vnuma = d->vnuma;
+    /*
+     * nr_vnodes <= 1 covers both the unset (0) and single-node cases;
+     * neither needs topology fixup.  The check also guarantees nr_vnodes >= 2
+     * below, so the d->max_vcpus % nr_vnodes modulo is safe.
+     */
+    if ( !vnuma || vnuma->nr_vnodes <= 1 )
+        return;
+
+    nr_vnodes = vnuma->nr_vnodes;
+
+    /* Guard against non-uniform vCPU distribution across vnodes. */
+    if ( !d->max_vcpus || d->max_vcpus % nr_vnodes )
+        return;
+
+    vcpus_per_node = d->max_vcpus / nr_vnodes;
+
+    /*
+     * All topology encodings below require vcpus_per_node to be a power of 2
+     * so the package boundary falls on a clean bit position in the APIC ID.
+     * Fall back to defaults (zeroed topo, host 80000008 values) if not.
+     */
+    if ( !vcpus_per_node || (vcpus_per_node & (vcpus_per_node - 1)) )
+        return;
+
+    /*
+     * fls(x) returns 1 + floor(log2(x)) for x > 0.  For a power-of-2
+     * vcpus_per_node this equals 1 + log2(vcpus_per_node), which is the
+     * shift distance to the package boundary in the x2APIC ID (one extra
+     * bit for the always-zero SMT slot at bit 0).
+     */
+    pkg_shift = fls(vcpus_per_node);
+
+    /*
+     * AMD/Hygon: correct CPUID 0x80000008 ECX to encode the virtual package
+     * size rather than the physical one.
+     *
+     * On AMD, without leaf 0x8000001D (zeroed by recalculate_misc()) and
+     * without leaf 0x8000001E (also zeroed), the Linux kernel falls back to
+     * CPUID 0x80000008 for package-topology detection:
+     *
+     *   ECX[7:0]   = NC:          logical processors per package, minus 1
+     *   ECX[15:12] = ApicIdSize:  bits in the (x2)APIC ID encoding the
+     *                             core within its physical package
+     *
+     * The host values reflect the physical package (e.g. NC=63, ApicIdSize=6
+     * for a 64-thread processor), so all vCPUs whose APIC IDs fit within 2^6
+     * = 64 entries appear to be in one package — which with vcpu_id*2 IDs
+     * covers the entire guest.  Linux then considers all vCPUs to be
+     * LLC-siblings and emits "topology_sane" WARN_ON splats when it finds
+     * CPUs it believes share the LLC straddling two different NUMA nodes.
+     *
+     * recalculate_misc() preserves ECX[15:12] and ECX[7:0] in its mask
+     * (0x0003f0ff covers bits [17:12] and [7:0]), so our values are not
+     * subsequently clobbered.
+     */
+    if ( p->x86_vendor & (X86_VENDOR_AMD | X86_VENDOR_HYGON) )
+    {
+        /* Clear ECX[15:12] (ApicIdSize) and ECX[7:0] (NC), then set both. */
+        p->extd.raw[0x8].c &= ~((uint32_t)0x0000f0ff);
+        p->extd.raw[0x8].c |= (pkg_shift << 12) | (vcpus_per_node - 1);
+    }
+
+    /*
+     * Leaf 0xB (Extended Topology Enumeration) is only meaningful when
+     * x2APIC is advertised.  The per-vCPU EDX fixup in guest_cpuid()
+     * case 0xb is also gated on x2apic.
+     */
+    if ( !p->basic.x2apic )
+        return;
+
+    /*
+     * Subleaf 0 — SMT level.
+     *
+     * EAX[4:0]  = 1: one bit spans the SMT level.  Bit 0 of vcpu_id * 2
+     *               is always 0, so every vCPU is alone at this level.
+     * EBX[15:0] = 1: one logical processor per "core" (no hyperthreading).
+     * ECX[15:8] = 1: level type = SMT.
+     * ECX[7:0]  = 0: subleaf index placeholder; the existing dynamic fixup
+     *               in guest_cpuid() case 0xb overwrites this with the
+     *               actual subleaf number at intercept time.
+     * EDX       = 0: x2APIC ID placeholder; filled per-vCPU by guest_cpuid().
+     */
+    p->topo.raw[0].a = 1;
+    p->topo.raw[0].b = 1;
+    p->topo.raw[0].c = 0x00000100; /* type=SMT(1), index=0 */
+    p->topo.raw[0].d = 0;
+
+    /*
+     * Subleaf 1 — Core/package level.
+     *
+     * EAX[4:0]  = pkg_shift: bits [pkg_shift-1:0] of the x2APIC ID identify
+     *               logical processors within the same package.
+     * EBX[15:0] = vcpus_per_node: logical processors per package.
+     * ECX[15:8] = 2: level type = Core.
+     * ECX[7:0]  = 1: subleaf index placeholder; overwritten by guest_cpuid().
+     * EDX       = 0: x2APIC ID placeholder; filled per-vCPU by guest_cpuid().
+     */
+    p->topo.raw[1].a = pkg_shift;
+    p->topo.raw[1].b = vcpus_per_node;
+    p->topo.raw[1].c = 0x00000201; /* type=Core(2), index=1 */
+    p->topo.raw[1].d = 0;
+
+    /*
+     * Subleaf 2 is the implicit terminator.  CPUID_GUEST_NR_TOPO == 2, so
+     * p->topo.raw has valid indices 0 and 1 only.  guest_cpuid() returns an
+     * all-zeros leaf for any subleaf >= ARRAY_SIZE(p->topo.raw), and ECX[15:8]
+     * = 0 (type = invalid) in that all-zeros response is what signals
+     * end-of-enumeration to the guest.  recalculate_misc() zeroed the array
+     * before we ran, so no explicit write is needed or possible here.
+     */
+}
+
 void calculate_raw_cpu_policy(void)
 {
     struct cpu_policy *p = &raw_cpu_policy;
@@ -945,6 +1117,7 @@ void recalculate_cpuid_policy(struct domain *d)
         : (IS_ENABLED(CONFIG_HVM) ? &hvm_max_cpu_policy : NULL);
     uint32_t fs[FSCAPINTS], max_fs[FSCAPINTS];
     unsigned int i;
+    int llc_idx = -1; /* index of the LLC subleaf in p->cache.raw, or -1 */
 
     if ( !max )
     {
@@ -1029,6 +1202,13 @@ void recalculate_cpuid_policy(struct domain *d)
     recalculate_xstate(p);
     recalculate_misc(p);
 
+    /*
+     * Populate vNUMA topology leaves from vNUMA configuration.
+     * recalculate_misc() above resets both p->topo.raw and the AMD
+     * 0x80000008 ECX fields, so this must come after it.
+     */
+    recalculate_vnuma_topo(d, p);
+
     for ( i = 0; i < ARRAY_SIZE(p->cache.raw); ++i )
     {
         if ( p->cache.subleaf[i].type >= 1 &&
@@ -1037,12 +1217,49 @@ void recalculate_cpuid_policy(struct domain *d)
             /* Subleaf has a valid cache type. Zero reserved fields. */
             p->cache.raw[i].a &= 0xffffc3ffu;
             p->cache.raw[i].d &= 0x00000007u;
+
+            /*
+             * Track the highest-level unified (type=3) cache as the LLC.
+             * Subleafs are enumerated in ascending cache-level order, so the
+             * last type=3 entry seen is the LLC.
+             */
+            if ( p->cache.subleaf[i].type == 3 )
+                llc_idx = i;
         }
         else
         {
             /* Subleaf is not valid.  Zero the rest of the union. */
             zero_leaves(p->cache.raw, i, ARRAY_SIZE(p->cache.raw) - 1);
             break;
+        }
+    }
+
+    /*
+     * Intel only: fix the LLC threads-sharing count in leaf 4 EAX[25:14]
+     * (0-based) for vNUMA guests.  The host value reflects the physical LLC
+     * sharing domain, which typically spans more CPUs than a single vNUMA
+     * node.  Linux's topology_sane() cross-checks this field against SRAT
+     * node assignments and emits a warning when they conflict.
+     *
+     * The corrected value is (vcpus_per_node - 1): each vNUMA node maps to
+     * one virtual package, and all vCPUs in that package share the LLC.
+     *
+     * AMD guests use leaf 0x8000001D for cache topology, which
+     * recalculate_misc() zeroes unconditionally.  The package-topology fix
+     * in recalculate_vnuma_topo() (CPUID 0x80000008 ECX) is sufficient to
+     * resolve LLC-sibling mismatches on AMD.
+     */
+    if ( llc_idx >= 0 &&
+         p->x86_vendor == X86_VENDOR_INTEL &&
+         d->vnuma && d->vnuma->nr_vnodes > 1 )
+    {
+        unsigned int cpn = d->max_vcpus / d->vnuma->nr_vnodes;
+
+        if ( cpn > 0 && !(cpn & (cpn - 1)) )
+        {
+            /* Clear EAX[25:14] and write (vcpus_per_node - 1). */
+            p->cache.raw[llc_idx].a &= ~((uint32_t)0xfff << 14);
+            p->cache.raw[llc_idx].a |= (cpn - 1) << 14;
         }
     }
 
@@ -1096,6 +1313,18 @@ void __init init_dom0_cpuid_policy(struct domain *d)
     if ( !opt_dom0_cpuid_faulting && is_control_domain(d) && is_pv_domain(d) )
         p->platform_info.cpuid_faulting = false;
 
+    recalculate_cpuid_policy(d);
+}
+
+/*
+ * Arch hook invoked by the common XEN_DOMCTL_setvnumainfo handler after
+ * d->vnuma has been installed and the domain has been paused.  Recalculates
+ * the CPUID policy fields that are derived from vNUMA topology: leaf 0xB
+ * subleaves and CPUID 0x80000008 ECX (AMD/Hygon), and leaf 4 LLC count
+ * (Intel).  The weak default in xen/common/domctl.c is a no-op.
+ */
+void arch_domain_update_vnuma(struct domain *d)
+{
     recalculate_cpuid_policy(d);
 }
 

--- a/xen/common/domctl.c
+++ b/xen/common/domctl.c
@@ -267,6 +267,14 @@ static struct vnuma_info *vnuma_init(const struct xen_domctl_vnuma *uinfo,
     return ERR_PTR(ret);
 }
 
+/*
+ * Arch hook called from XEN_DOMCTL_setvnumainfo after d->vnuma is installed
+ * and the domain is paused.  Allows architectures to recalculate any state
+ * derived from vNUMA topology (e.g. CPUID topology leaves on x86).
+ * The strong definition lives in arch/x86/cpu-policy.c.
+ */
+void __weak arch_domain_update_vnuma(struct domain *d) {}
+
 static bool is_stable_domctl(uint32_t cmd)
 {
     return cmd == XEN_DOMCTL_get_domain_state;
@@ -808,11 +816,21 @@ long do_domctl(XEN_GUEST_HANDLE_PARAM(xen_domctl_t) u_domctl)
             break;
         }
 
-        /* overwrite vnuma topology for domain. */
+        /* Overwrite vnuma topology for domain. */
         write_lock(&d->vnuma_rwlock);
         vnuma_destroy(d->vnuma);
         d->vnuma = vnuma;
         write_unlock(&d->vnuma_rwlock);
+
+        /*
+         * Notify the architecture layer that vNUMA topology has changed.
+         * On x86 this recalculates CPUID topology leaves (leaf 0xB and
+         * 0x80000008 ECX) that are derived from the vNUMA node count and
+         * vCPU-per-node distribution.  This domctl is a construction-time
+         * operation issued before the domain is started, so no domain_pause()
+         * is required.
+         */
+        arch_domain_update_vnuma(d);
 
         break;
     }


### PR DESCRIPTION
When vNUMA is configured, we should automatically patch the CPU topology.

This ensures that `hwloc` sees distinct packages per NUMA node:
```
  Package L#0
    NUMANode L#0 (P#0 5937MB)
    L3 L#0 (128MB)
      L2 L#0 (1024KB) + L1d L#0 (48KB) + L1i L#0 (32KB) + Core L#0 + PU L#0 (P#0)
      L2 L#1 (1024KB) + L1d L#1 (48KB) + L1i L#1 (32KB) + Core L#1 + PU L#1 (P#1)
      L2 L#2 (1024KB) + L1d L#2 (48KB) + L1i L#2 (32KB) + Core L#2 + PU L#2 (P#2)
      L2 L#3 (1024KB) + L1d L#3 (48KB) + L1i L#3 (32KB) + Core L#3 + PU L#3 (P#3)
      L2 L#4 (1024KB) + L1d L#4 (48KB) + L1i L#4 (32KB) + Core L#4 + PU L#4 (P#4)
      L2 L#5 (1024KB) + L1d L#5 (48KB) + L1i L#5 (32KB) + Core L#5 + PU L#5 (P#5)
      L2 L#6 (1024KB) + L1d L#6 (48KB) + L1i L#6 (32KB) + Core L#6 + PU L#6 (P#6)
      L2 L#7 (1024KB) + L1d L#7 (48KB) + L1i L#7 (32KB) + Core L#7 + PU L#7 (P#7)
      L2 L#8 (1024KB) + L1d L#8 (48KB) + L1i L#8 (32KB) + Core L#8 + PU L#8 (P#8)
      L2 L#9 (1024KB) + L1d L#9 (48KB) + L1i L#9 (32KB) + Core L#9 + PU L#9 (P#9)
      L2 L#10 (1024KB) + L1d L#10 (48KB) + L1i L#10 (32KB) + Core L#10 + PU L#10 (P#10)
      L2 L#11 (1024KB) + L1d L#11 (48KB) + L1i L#11 (32KB) + Core L#11 + PU L#11 (P#11)
      L2 L#12 (1024KB) + L1d L#12 (48KB) + L1i L#12 (32KB) + Core L#12 + PU L#12 (P#12)
      L2 L#13 (1024KB) + L1d L#13 (48KB) + L1i L#13 (32KB) + Core L#13 + PU L#13 (P#13)
      L2 L#14 (1024KB) + L1d L#14 (48KB) + L1i L#14 (32KB) + Core L#14 + PU L#14 (P#14)
      L2 L#15 (1024KB) + L1d L#15 (48KB) + L1i L#15 (32KB) + Core L#15 + PU L#15 (P#15)
  Package L#1
    NUMANode L#1 (P#1 6032MB)
    L3 L#1 (128MB)
      L2 L#16 (1024KB) + L1d L#16 (48KB) + L1i L#16 (32KB) + Core L#16 + PU L#16 (P#16)
      L2 L#17 (1024KB) + L1d L#17 (48KB) + L1i L#17 (32KB) + Core L#17 + PU L#17 (P#17)
      L2 L#18 (1024KB) + L1d L#18 (48KB) + L1i L#18 (32KB) + Core L#18 + PU L#18 (P#18)
      L2 L#19 (1024KB) + L1d L#19 (48KB) + L1i L#19 (32KB) + Core L#19 + PU L#19 (P#19)
      L2 L#20 (1024KB) + L1d L#20 (48KB) + L1i L#20 (32KB) + Core L#20 + PU L#20 (P#20)
      L2 L#21 (1024KB) + L1d L#21 (48KB) + L1i L#21 (32KB) + Core L#21 + PU L#21 (P#21)
      L2 L#22 (1024KB) + L1d L#22 (48KB) + L1i L#22 (32KB) + Core L#22 + PU L#22 (P#22)
      L2 L#23 (1024KB) + L1d L#23 (48KB) + L1i L#23 (32KB) + Core L#23 + PU L#23 (P#23)
      L2 L#24 (1024KB) + L1d L#24 (48KB) + L1i L#24 (32KB) + Core L#24 + PU L#24 (P#24)
      L2 L#25 (1024KB) + L1d L#25 (48KB) + L1i L#25 (32KB) + Core L#25 + PU L#25 (P#25)
      L2 L#26 (1024KB) + L1d L#26 (48KB) + L1i L#26 (32KB) + Core L#26 + PU L#26 (P#26)
      L2 L#27 (1024KB) + L1d L#27 (48KB) + L1i L#27 (32KB) + Core L#27 + PU L#27 (P#27)
      L2 L#28 (1024KB) + L1d L#28 (48KB) + L1i L#28 (32KB) + Core L#28 + PU L#28 (P#28)
      L2 L#29 (1024KB) + L1d L#29 (48KB) + L1i L#29 (32KB) + Core L#29 + PU L#29 (P#29)
      L2 L#30 (1024KB) + L1d L#30 (48KB) + L1i L#30 (32KB) + Core L#30 + PU L#30 (P#30)
      L2 L#31 (1024KB) + L1d L#31 (48KB) + L1i L#31 (32KB) + Core L#31 + PU L#31 (P#31)
```

And `lscpu` sees the same:
```
# lscpu | grep -e Socket -e ' per '
Thread(s) per core:                      1
Core(s) per socket:                      16
Socket(s):                               2
```

And most importantly, the LLVM OpenMP runtime enumerates the topology correctly too. It's possible to build the LLVM OpenMP runtime with `hwloc` support, but most people don't do that, so it uses CPUID topology for enumeration -- and it doesn't notice the socket distinction. With this patch, it does (`env KMP_AFFINITY=verbose` output below):
```
OMP: Info #155: KMP_AFFINITY: Initial OS proc set respected: 0-31
OMP: Info #216: KMP_AFFINITY: decoding x2APIC ids.
OMP: Info #157: KMP_AFFINITY: 32 available OS procs
OMP: Info #158: KMP_AFFINITY: Uniform topology
OMP: Info #289: KMP_AFFINITY: topology layer "LL cache" is equivalent to "socket".
OMP: Info #191: KMP_AFFINITY: 2 sockets x 16 cores/socket x 1 thread/core (32 total cores)
OMP: Info #218: KMP_AFFINITY: OS proc to physical thread map:
OMP: Info #172: KMP_AFFINITY: OS proc 0 maps to socket 0 core 0 thread 0
OMP: Info #172: KMP_AFFINITY: OS proc 1 maps to socket 0 core 1 thread 1
OMP: Info #172: KMP_AFFINITY: OS proc 2 maps to socket 0 core 2 thread 2
OMP: Info #172: KMP_AFFINITY: OS proc 3 maps to socket 0 core 3 thread 3
OMP: Info #172: KMP_AFFINITY: OS proc 4 maps to socket 0 core 4 thread 4
OMP: Info #172: KMP_AFFINITY: OS proc 5 maps to socket 0 core 5 thread 5
OMP: Info #172: KMP_AFFINITY: OS proc 6 maps to socket 0 core 6 thread 6
OMP: Info #172: KMP_AFFINITY: OS proc 7 maps to socket 0 core 7 thread 7
OMP: Info #172: KMP_AFFINITY: OS proc 8 maps to socket 0 core 8 thread 8
OMP: Info #172: KMP_AFFINITY: OS proc 9 maps to socket 0 core 9 thread 9
OMP: Info #172: KMP_AFFINITY: OS proc 10 maps to socket 0 core 10 thread 10
OMP: Info #172: KMP_AFFINITY: OS proc 11 maps to socket 0 core 11 thread 11
OMP: Info #172: KMP_AFFINITY: OS proc 12 maps to socket 0 core 12 thread 12
OMP: Info #172: KMP_AFFINITY: OS proc 13 maps to socket 0 core 13 thread 13
OMP: Info #172: KMP_AFFINITY: OS proc 14 maps to socket 0 core 14 thread 14
OMP: Info #172: KMP_AFFINITY: OS proc 15 maps to socket 0 core 15 thread 15
OMP: Info #172: KMP_AFFINITY: OS proc 16 maps to socket 1 core 16 thread 16
OMP: Info #172: KMP_AFFINITY: OS proc 17 maps to socket 1 core 17 thread 17
OMP: Info #172: KMP_AFFINITY: OS proc 18 maps to socket 1 core 18 thread 18
OMP: Info #172: KMP_AFFINITY: OS proc 19 maps to socket 1 core 19 thread 19
OMP: Info #172: KMP_AFFINITY: OS proc 20 maps to socket 1 core 20 thread 20
OMP: Info #172: KMP_AFFINITY: OS proc 21 maps to socket 1 core 21 thread 21
OMP: Info #172: KMP_AFFINITY: OS proc 22 maps to socket 1 core 22 thread 22
OMP: Info #172: KMP_AFFINITY: OS proc 23 maps to socket 1 core 23 thread 23
OMP: Info #172: KMP_AFFINITY: OS proc 24 maps to socket 1 core 24 thread 24
OMP: Info #172: KMP_AFFINITY: OS proc 25 maps to socket 1 core 25 thread 25
OMP: Info #172: KMP_AFFINITY: OS proc 26 maps to socket 1 core 26 thread 26
OMP: Info #172: KMP_AFFINITY: OS proc 27 maps to socket 1 core 27 thread 27
OMP: Info #172: KMP_AFFINITY: OS proc 28 maps to socket 1 core 28 thread 28
OMP: Info #172: KMP_AFFINITY: OS proc 29 maps to socket 1 core 29 thread 29
OMP: Info #172: KMP_AFFINITY: OS proc 30 maps to socket 1 core 30 thread 30
OMP: Info #172: KMP_AFFINITY: OS proc 31 maps to socket 1 core 31 thread 31
OMP: Info #145: KMP_AFFINITY: Threads may migrate across 1 innermost levels of machine
```

The only downside is that this currently only works with power-of-two vCPU counts, but I think it's sufficient for most cases that will care.