### PR TITLE
arch/x86: assume TSC_RELIABLE_SOCKET if we have TSC_ADJUST and ITSC

### DIFF
--- a/xen/arch/x86/time.c
+++ b/xen/arch/x86/time.c
@@ -665,6 +665,11 @@ static int64_t __init cf_check init_tsc(struct platform_timesource *pts)
         ret = 0;
     }
 
+    if ( boot_cpu_has(X86_FEATURE_TSC_ADJUST) && boot_cpu_has(X86_FEATURE_ITSC) )
+    {
+        tsc_flags |= TSC_RELIABLE_SOCKET;
+    }
+
     if ( nr_sockets > 1 && !(tsc_flags & TSC_RELIABLE_SOCKET) )
     {
         printk(XENLOG_WARNING "TSC: Not invariant across sockets\n");


### PR DESCRIPTION
If we have `IA32_MSR_TSC_ADJUST` and invariant TSC, we can reliably synchronize the TSC even across sockets, so we should implicitly have `TSC_RELIABLE_SOCKET`.