### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kaniini @azenla @bleggett @tycho


### PR DESCRIPTION
Adds a CODEOWNERS file requiring review from one of the listed owners on any change to this repo. Pairs with the branch protection ruleset I'll apply today on edera/* branches.