### PR TITLE
vNUMA: implement CPUID patch for NPOT domU vCPU counts, implement PVH dom0 vNUMA

### DIFF
--- a/xen/arch/x86/cpu-policy.c
+++ b/xen/arch/x86/cpu-policy.c
@@ -10,6 +10,7 @@
 #include <asm/cpu-policy.h>
 #include <asm/hvm/nestedhvm.h>
 #include <asm/hvm/svm/svm.h>
+#include <asm/hvm/vlapic.h>
 #include <asm/intel-family.h>
 #include <asm/msr-index.h>
 #include <asm/paging.h>
@@ -364,21 +365,47 @@ static void recalculate_misc(struct cpu_policy *p)
  *    populate the structural subleaf fields from vNUMA config; the per-vCPU
  *    EDX fixup already present in guest_cpuid() case 0xb requires no changes.
  *
- * x2APIC IDs are assigned as (vcpu_id * 2) by the dynamic fixup in
- * guest_cpuid().  Bit 0 is permanently clear — each vCPU is a single-threaded
- * core with no SMT sibling.  The NUMA-node (package) boundary falls at bit
- * pkg_shift, where:
+ * x2APIC IDs are constructed from (vnode_index, intra_package_offset) by the
+ * dynamic fixup in guest_cpuid() as:
  *
- *   pkg_shift = 1 (SMT bit) + log2(vcpus_per_node)
+ *   apic_id = (vnode_index << pkg_shift) | (intra_package_offset * 2)
  *
- * Example with 16 vCPUs per node across 2 vNUMA nodes (32 vCPUs total):
- *   pkg_shift = 5; IDs 0-30  (vcpu_id  0-15) → package 0 (bit 5 = 0)
- *               5; IDs 32-62 (vcpu_id 16-31) → package 1 (bit 5 = 1)
+ * where pkg_shift is chosen so the per-package APIC ID window is the smallest
+ * power of two large enough to hold the largest vnode's vCPUs (counting only
+ * even APIC IDs, since bit 0 is the always-clear SMT slot):
  *
- * This encoding is only valid when vcpus_per_node is a power of 2 and vCPUs
- * are assigned to vNUMA nodes in contiguous ascending order (0..N-1 → node 0,
- * N..2N-1 → node 1, etc.), which is assumed to be the case when the toolstack
- * calls XEN_DOMCTL_SETVNUMAINFO before XEN_DOMCTL_set_cpu_policy.
+ *   pkg_shift = fls(2 * max_per_node - 1)
+ *
+ * Two consequences worth flagging:
+ *
+ * 1. APIC IDs are not necessarily contiguous across packages.  With
+ *    max_per_node = 24, each package consumes a 64-slot window (pkg_shift = 6)
+ *    but only 24 even IDs are used, leaving holes 48-63 in package 0 unused
+ *    before package 1 begins at 64.  Linux tolerates holes; it iterates over
+ *    online vCPUs rather than the contiguous range.
+ *
+ * 2. Unbalanced vnodes (e.g. 25/24 from a 49-vCPU domain) are advertised with
+ *    EBX[15:0] = max_per_node (25), even though one package contains fewer
+ *    real vCPUs than that.  Intel SDM treats EBX as a hint for software
+ *    sizing decisions, not a strict invariant.
+ *
+ * Examples:
+ *
+ *   16 vCPUs/node × 2 nodes (POT):
+ *     pkg_shift = 5; IDs 0-30  (vcpu  0-15) → package 0
+ *                 5; IDs 32-62 (vcpu 16-31) → package 1
+ *
+ *   24 vCPUs/node × 2 nodes (NPOT, balanced):
+ *     pkg_shift = 6; IDs 0-46    (vcpu  0-23) → package 0
+ *                 6; IDs 64-110  (vcpu 24-47) → package 1
+ *
+ *   25/24 split (NPOT, unbalanced):
+ *     pkg_shift = 6; IDs 0-48    (vcpu  0-24) → package 0
+ *                 6; IDs 64-110  (vcpu 25-48) → package 1
+ *
+ * vCPUs are not required to be assigned to vnodes in contiguous ascending
+ * order; intra_package_offset is computed from a walk over vcpu_to_vnode[],
+ * so any ordering produces correct APIC IDs.
  *
  * Leaf 0x1F (Extended Topology v2, preferred over 0xB by LLVM OpenMP and
  * other modern runtimes per Intel SDM Vol. 2A) is not handled here because:
@@ -392,40 +419,71 @@ static void recalculate_misc(struct cpu_policy *p)
 static void recalculate_vnuma_topo(const struct domain *d, struct cpu_policy *p)
 {
     const struct vnuma_info *vnuma;
-    unsigned int nr_vnodes, vcpus_per_node, pkg_shift;
+    unsigned int i, nr_vnodes, max_per_node, pkg_shift;
+    bool extended = d->options & XEN_DOMCTL_CDF_vnuma_apic_topology;
 
     vnuma = d->vnuma;
     /*
      * nr_vnodes <= 1 covers both the unset (0) and single-node cases;
-     * neither needs topology fixup.  The check also guarantees nr_vnodes >= 2
-     * below, so the d->max_vcpus % nr_vnodes modulo is safe.
+     * neither needs topology fixup.
      */
-    if ( !vnuma || vnuma->nr_vnodes <= 1 )
+    if ( !vnuma || vnuma->nr_vnodes <= 1 || !d->max_vcpus )
         return;
 
     nr_vnodes = vnuma->nr_vnodes;
 
-    /* Guard against non-uniform vCPU distribution across vnodes. */
-    if ( !d->max_vcpus || d->max_vcpus % nr_vnodes )
-        return;
+    /*
+     * Determine the largest per-vnode vCPU count.  In the legacy
+     * (non-opted-in) path we require all vnodes to have the same
+     * power-of-two count -- this preserves the upstream behavior that
+     * silently falls back to default CPUID for any layout that does not
+     * fit a clean APIC ID bit boundary.
+     *
+     * When XEN_DOMCTL_CDF_vnuma_apic_topology is set, we instead walk
+     * vcpu_to_vnode[] to find the largest vnode and use that as the
+     * window size; pkg_shift is rounded up to the next power-of-two big
+     * enough to hold it, and smaller vnodes simply leave the tail of
+     * their window unused.  This requires the toolstack to source MADT
+     * APIC IDs from XEN_DOMCTL_get_vcpu_apicids (see guest_vcpu_x2apic_id
+     * in cpuid.c) -- which is exactly the contract the CDF flag opts
+     * into.
+     */
+    if ( !extended )
+    {
+        if ( d->max_vcpus % nr_vnodes )
+            return;
+        max_per_node = d->max_vcpus / nr_vnodes;
+        if ( !max_per_node || (max_per_node & (max_per_node - 1)) )
+            return;
+    }
+    else
+    {
+        max_per_node = 0;
+        for ( i = 0; i < nr_vnodes; i++ )
+        {
+            unsigned int j, count = 0;
 
-    vcpus_per_node = d->max_vcpus / nr_vnodes;
+            for ( j = 0; j < d->max_vcpus; j++ )
+                if ( vnuma->vcpu_to_vnode[j] == i )
+                    count++;
+
+            if ( count > max_per_node )
+                max_per_node = count;
+        }
+
+        if ( !max_per_node )
+            return;
+    }
 
     /*
-     * All topology encodings below require vcpus_per_node to be a power of 2
-     * so the package boundary falls on a clean bit position in the APIC ID.
-     * Fall back to defaults (zeroed topo, host 80000008 values) if not.
+     * pkg_shift is the smallest n such that 2^n >= 2 * max_per_node, i.e.
+     * the package window must hold max_per_node even APIC IDs (bit 0 is
+     * the always-clear SMT slot).  For max_per_node = 16 this gives
+     * pkg_shift = 5 (matching the legacy POT-only encoding); for
+     * max_per_node = 24 it gives pkg_shift = 6, leaving APIC IDs 48-63
+     * unused in each package.
      */
-    if ( !vcpus_per_node || (vcpus_per_node & (vcpus_per_node - 1)) )
-        return;
-
-    /*
-     * fls(x) returns 1 + floor(log2(x)) for x > 0.  For a power-of-2
-     * vcpus_per_node this equals 1 + log2(vcpus_per_node), which is the
-     * shift distance to the package boundary in the x2APIC ID (one extra
-     * bit for the always-zero SMT slot at bit 0).
-     */
-    pkg_shift = fls(vcpus_per_node);
+    pkg_shift = fls(2 * max_per_node - 1);
 
     /*
      * AMD/Hygon: correct CPUID 0x80000008 ECX to encode the virtual package
@@ -452,9 +510,13 @@ static void recalculate_vnuma_topo(const struct domain *d, struct cpu_policy *p)
      */
     if ( p->x86_vendor & (X86_VENDOR_AMD | X86_VENDOR_HYGON) )
     {
-        /* Clear ECX[15:12] (ApicIdSize) and ECX[7:0] (NC), then set both. */
+        /*
+         * Clear ECX[15:12] (ApicIdSize) and ECX[7:0] (NC), then set both.
+         * For unbalanced vnodes, we advertise the largest package's size;
+         * underfilled packages just look like they have idle slots.
+         */
         p->extd.raw[0x8].c &= ~((uint32_t)0x0000f0ff);
-        p->extd.raw[0x8].c |= (pkg_shift << 12) | (vcpus_per_node - 1);
+        p->extd.raw[0x8].c |= (pkg_shift << 12) | (max_per_node - 1);
     }
 
     /*
@@ -468,8 +530,10 @@ static void recalculate_vnuma_topo(const struct domain *d, struct cpu_policy *p)
     /*
      * Subleaf 0 — SMT level.
      *
-     * EAX[4:0]  = 1: one bit spans the SMT level.  Bit 0 of vcpu_id * 2
-     *               is always 0, so every vCPU is alone at this level.
+     * EAX[4:0]  = 1: one bit spans the SMT level.  The per-vCPU APIC ID
+     *               assigned by guest_cpuid() always has bit 0 = 0
+     *               (low half is offset * 2), so every vCPU is alone at
+     *               this level — no SMT siblings exposed to the guest.
      * EBX[15:0] = 1: one logical processor per "core" (no hyperthreading).
      * ECX[15:8] = 1: level type = SMT.
      * ECX[7:0]  = 0: subleaf index placeholder; the existing dynamic fixup
@@ -487,13 +551,14 @@ static void recalculate_vnuma_topo(const struct domain *d, struct cpu_policy *p)
      *
      * EAX[4:0]  = pkg_shift: bits [pkg_shift-1:0] of the x2APIC ID identify
      *               logical processors within the same package.
-     * EBX[15:0] = vcpus_per_node: logical processors per package.
+     * EBX[15:0] = max_per_node: logical processors per package (largest vnode;
+     *               unbalanced layouts advertise the max and underfill).
      * ECX[15:8] = 2: level type = Core.
      * ECX[7:0]  = 1: subleaf index placeholder; overwritten by guest_cpuid().
      * EDX       = 0: x2APIC ID placeholder; filled per-vCPU by guest_cpuid().
      */
     p->topo.raw[1].a = pkg_shift;
-    p->topo.raw[1].b = vcpus_per_node;
+    p->topo.raw[1].b = max_per_node;
     p->topo.raw[1].c = 0x00000201; /* type=Core(2), index=1 */
     p->topo.raw[1].d = 0;
 
@@ -1241,8 +1306,9 @@ void recalculate_cpuid_policy(struct domain *d)
      * node.  Linux's topology_sane() cross-checks this field against SRAT
      * node assignments and emits a warning when they conflict.
      *
-     * The corrected value is (vcpus_per_node - 1): each vNUMA node maps to
-     * one virtual package, and all vCPUs in that package share the LLC.
+     * The corrected value is (max_per_node - 1).  For unbalanced vnodes we
+     * advertise the largest package's size; underfilled packages just look
+     * like the LLC has unused threads, which Linux tolerates.
      *
      * AMD guests use leaf 0x8000001D for cache topology, which
      * recalculate_misc() zeroes unconditionally.  The package-topology fix
@@ -1251,15 +1317,48 @@ void recalculate_cpuid_policy(struct domain *d)
      */
     if ( llc_idx >= 0 &&
          p->x86_vendor == X86_VENDOR_INTEL &&
-         d->vnuma && d->vnuma->nr_vnodes > 1 )
+         d->vnuma && d->vnuma->nr_vnodes > 1 && d->max_vcpus )
     {
-        unsigned int cpn = d->max_vcpus / d->vnuma->nr_vnodes;
+        const struct vnuma_info *vnuma = d->vnuma;
+        bool extended = d->options & XEN_DOMCTL_CDF_vnuma_apic_topology;
+        unsigned int i, max_per_node = 0;
 
-        if ( cpn > 0 && !(cpn & (cpn - 1)) )
+        /*
+         * Without the CDF opt-in, only patch for the layouts upstream Xen
+         * has historically handled: balanced power-of-two per-vnode counts.
+         * With the opt-in, compute the largest per-vnode count and use it
+         * as the LLC scope; smaller vnodes have a few advertised siblings
+         * that don't exist, which Linux tolerates.
+         */
+        if ( !extended )
         {
-            /* Clear EAX[25:14] and write (vcpus_per_node - 1). */
+            if ( d->max_vcpus % vnuma->nr_vnodes == 0 )
+            {
+                unsigned int cpn = d->max_vcpus / vnuma->nr_vnodes;
+                if ( cpn > 0 && !(cpn & (cpn - 1)) )
+                    max_per_node = cpn;
+            }
+        }
+        else
+        {
+            for ( i = 0; i < vnuma->nr_vnodes; i++ )
+            {
+                unsigned int j, count = 0;
+
+                for ( j = 0; j < d->max_vcpus; j++ )
+                    if ( vnuma->vcpu_to_vnode[j] == i )
+                        count++;
+
+                if ( count > max_per_node )
+                    max_per_node = count;
+            }
+        }
+
+        if ( max_per_node > 0 )
+        {
+            /* Clear EAX[25:14] and write (max_per_node - 1). */
             p->cache.raw[llc_idx].a &= ~((uint32_t)0xfff << 14);
-            p->cache.raw[llc_idx].a |= (cpn - 1) << 14;
+            p->cache.raw[llc_idx].a |= (max_per_node - 1) << 14;
         }
     }
 
@@ -1322,10 +1421,35 @@ void __init init_dom0_cpuid_policy(struct domain *d)
  * the CPUID policy fields that are derived from vNUMA topology: leaf 0xB
  * subleaves and CPUID 0x80000008 ECX (AMD/Hygon), and leaf 4 LLC count
  * (Intel).  The weak default in xen/common/domctl.c is a no-op.
+ *
+ * For HVM domains that opted into the vNUMA-derived APIC ID encoding
+ * (XEN_DOMCTL_CDF_vnuma_apic_topology), we also re-derive each vCPU's APIC
+ * ID under the updated encoding so the value stored in the vlapic register
+ * state stays consistent with CPUID 0xB.  Without this, vCPUs created
+ * before the setvnumainfo would keep their initial vcpu_id * 2 APIC IDs
+ * while the guest-visible CPUID 0xB EDX advertises the (vnode_index,
+ * intra_pkg_offset) encoding -- a mismatch that breaks Linux's topology
+ * detection.
+ *
+ * Domains without the CDF flag set keep their vcpu_id * 2 APIC IDs;
+ * recalculate_vnuma_topo above also restricts itself to layouts that
+ * agree with that encoding, so no reinit is required.
+ *
+ * Safe because setvnumainfo is a construction-time operation: the domain
+ * has not been unpaused yet, so no vCPU is observing APIC state.
  */
 void arch_domain_update_vnuma(struct domain *d)
 {
     recalculate_cpuid_policy(d);
+
+    if ( is_hvm_domain(d) &&
+         (d->options & XEN_DOMCTL_CDF_vnuma_apic_topology) )
+    {
+        struct vcpu *v;
+
+        for_each_vcpu ( d, v )
+            vlapic_reinit_apic_id(v);
+    }
 }
 
 static void __init __maybe_unused build_assertions(void)

--- a/xen/arch/x86/cpuid.c
+++ b/xen/arch/x86/cpuid.c
@@ -169,6 +169,44 @@ static void cpuid_hypervisor_leaves(const struct vcpu *v, uint32_t leaf,
     }
 }
 
+uint32_t guest_vcpu_x2apic_id(const struct domain *d, unsigned int vcpu_id)
+{
+    const struct cpu_policy *p = d->arch.cpu_policy;
+    const struct vnuma_info *vnuma = d->vnuma;
+    unsigned int pkg_shift = p ? p->topo.raw[1].a : 0;
+
+    /*
+     * The vNUMA-derived encoding is opt-in (XEN_DOMCTL_CDF_vnuma_apic_topology
+     * at createdomain).  Domains without the flag stay on the legacy
+     * vcpu_id * 2 encoding regardless of vNUMA configuration -- this keeps
+     * Xen wire-compatible with toolstacks that hardcode `vcpu_id * 2` in
+     * MADT (libxl and friends).
+     *
+     * Even with the flag, the helper only diverges from the legacy formula
+     * when the domain has a real multi-vnode layout that
+     * recalculate_vnuma_topo() actually patched (pkg_shift > 0).  For
+     * POT-balanced vnodes the new encoding is bit-identical to vcpu_id * 2,
+     * so opted-in toolstacks observe a change only for the layouts the
+     * legacy code couldn't represent at all.
+     */
+    if ( (d->options & XEN_DOMCTL_CDF_vnuma_apic_topology) &&
+         vnuma && vnuma->nr_vnodes > 1 && pkg_shift > 0 &&
+         vcpu_id < d->max_vcpus )
+    {
+        unsigned int vnode = vnuma->vcpu_to_vnode[vcpu_id];
+        unsigned int offset = 0;
+        unsigned int i;
+
+        for ( i = 0; i < vcpu_id; i++ )
+            if ( vnuma->vcpu_to_vnode[i] == vnode )
+                offset++;
+
+        return (vnode << pkg_shift) | (offset * 2);
+    }
+
+    return vcpu_id * 2;
+}
+
 void guest_cpuid(const struct vcpu *v, uint32_t leaf,
                  uint32_t subleaf, struct cpuid_leaf *res)
 {
@@ -278,7 +316,7 @@ void guest_cpuid(const struct vcpu *v, uint32_t leaf,
         /* TODO: Rework topology logic. */
         res->b &= 0x00ffffffu;
         if ( is_hvm_domain(d) )
-            res->b |= (v->vcpu_id * 2) << 24;
+            res->b |= guest_vcpu_x2apic_id(d, v->vcpu_id) << 24;
 
         /* TODO: Rework vPMU control in terms of toolstack choices. */
         if ( vpmu_available(v) &&
@@ -458,8 +496,8 @@ void guest_cpuid(const struct vcpu *v, uint32_t leaf,
         {
             *(uint8_t *)&res->c = subleaf;
 
-            /* Fix the x2APIC identifier. */
-            res->d = v->vcpu_id * 2;
+            /* Fix the x2APIC identifier — vNUMA-aware encoding. */
+            res->d = guest_vcpu_x2apic_id(d, v->vcpu_id);
         }
         break;
 

--- a/xen/arch/x86/dom0_build.c
+++ b/xen/arch/x86/dom0_build.c
@@ -262,6 +262,38 @@ struct vcpu *__init alloc_dom0_vcpu0(struct domain *dom0)
     return vcpu_create(dom0, 0);
 }
 
+/*
+ * Detection gate for dom0 vNUMA topology.
+ *
+ * Enables a vNUMA-derived NUMA topology for dom0 (SRAT, SLIT, CPUID 0xB,
+ * per-node memory binding) only when all of the following hold:
+ *
+ *  - dom0 is PVH.  PV dom0 cannot observe vNUMA via the standard ACPI
+ *    path because Xen filters SRAT/SLIT out of the tables passed through
+ *    to dom0.
+ *  - dom0 vCPUs are hard-pinned 1:1 to pCPUs (`dom0_vcpus_pin=1`).
+ *  - dom0's vCPU count equals the present pCPU count, so every pCPU has a
+ *    corresponding dom0 vCPU and the layout is the identity mapping
+ *    `vcpu_to_vnode[N] = cpu_to_node(N)`.
+ *  - The host actually has more than one NUMA node.
+ *
+ * Under these conditions there are no layout decisions to make: the
+ * topology directly mirrors the host.
+ */
+bool __init dom0_vnuma_enabled(unsigned int max_vcpus)
+{
+    if ( !opt_dom0_pvh )
+        return false;
+    if ( !opt_dom0_vcpus_pin )
+        return false;
+    if ( max_vcpus != num_present_cpus() )
+        return false;
+    if ( num_online_nodes() <= 1 )
+        return false;
+
+    return true;
+}
+
 #ifdef CONFIG_SHADOW_PAGING
 bool __initdata opt_dom0_shadow;
 #endif

--- a/xen/arch/x86/domctl.c
+++ b/xen/arch/x86/domctl.c
@@ -1359,6 +1359,62 @@ long arch_do_domctl(
             copyback = true;
         break;
 
+    case XEN_DOMCTL_get_vcpu_apicids:
+    {
+        /*
+         * Return the per-vCPU x2APIC identifiers currently assigned by Xen.
+         * Toolstacks generating ACPI MADT processor entries must source
+         * APIC IDs from here so the MADT agrees with the values the guest
+         * reads from CPUID 0xB and the vlapic register state.  This matters
+         * for vNUMA layouts with non-power-of-two or unbalanced per-vnode
+         * vCPU counts, where the APIC ID encoding is non-trivial; for
+         * legacy / single-vnode layouts each ID is simply (vcpu_id * 2).
+         *
+         * Buffer sizing follows the XEN_DOMCTL_get_vcpu_msrs convention:
+         * a NULL apicid_array (or nr_vcpus == 0) is a capacity query that
+         * returns d->max_vcpus in nr_filled.  An insufficient buffer
+         * returns -ENOBUFS, also with nr_filled = d->max_vcpus.
+         */
+        struct xen_domctl_get_vcpu_apicids *cmd = &domctl->u.get_vcpu_apicids;
+        unsigned int max = d->max_vcpus;
+        uint32_t *buf;
+
+        ret = 0;
+        copyback = true;
+
+        /* Capacity query: NULL handle or zero count. */
+        if ( guest_handle_is_null(cmd->apicid_array) || cmd->nr_vcpus == 0 )
+        {
+            cmd->nr_filled = max;
+            break;
+        }
+
+        if ( cmd->nr_vcpus < max )
+        {
+            cmd->nr_filled = max;
+            ret = -ENOBUFS;
+            break;
+        }
+
+        buf = xmalloc_array(uint32_t, max);
+        if ( !buf )
+        {
+            ret = -ENOMEM;
+            break;
+        }
+
+        for ( i = 0; i < max; i++ )
+            buf[i] = guest_vcpu_x2apic_id(d, i);
+
+        if ( copy_to_guest(cmd->apicid_array, buf, max) )
+            ret = -EFAULT;
+        else
+            cmd->nr_filled = max;
+
+        xfree(buf);
+        break;
+    }
+
     default:
         ret = -ENOSYS;
         break;

--- a/xen/arch/x86/hvm/dom0_build.c
+++ b/xen/arch/x86/hvm/dom0_build.c
@@ -22,6 +22,7 @@
 
 #include <asm/bootinfo.h>
 #include <asm/bzimage.h>
+#include <asm/cpu-policy.h>
 #include <asm/dom0_build.h>
 #include <asm/hvm/support.h>
 #include <asm/io_apic.h>
@@ -950,7 +951,13 @@ static int __init pvh_setup_acpi_madt(struct domain *d, paddr_t *addr)
         x2apic->header.type = ACPI_MADT_TYPE_LOCAL_X2APIC;
         x2apic->header.length = sizeof(*x2apic);
         x2apic->uid = i;
-        x2apic->local_apic_id = i * 2;
+        /*
+         * Source APIC IDs from guest_vcpu_x2apic_id() so MADT agrees with
+         * the values dom0 reads from CPUID 0xB and the vlapic register
+         * state.  Without a vNUMA topology installed (or with the CDF
+         * flag unset), the helper returns vcpu_id * 2.
+         */
+        x2apic->local_apic_id = guest_vcpu_x2apic_id(d, i);
         x2apic->lapic_flags = ACPI_MADT_ENABLED;
         x2apic++;
     }

--- a/xen/arch/x86/hvm/dom0_build.c
+++ b/xen/arch/x86/hvm/dom0_build.c
@@ -1701,15 +1701,41 @@ static int __init dom0_setup_vnuma(struct domain *d)
     for_each_node_mask ( node, used_nodes )
         pnodes[i++] = node;
 
-    /* One vmemrange per (E820 RAM region, vnode) pair. */
-    for ( i = 0; i < d->arch.nr_e820; i++ )
-        if ( d->arch.e820[i].type == E820_RAM )
-            nr_vmemranges += nr_vnodes;
+    /*
+     * Count vmemranges = number of physical NUMA memblks owned by nodes
+     * dom0 spans.  We emit one vmemrange per memblk, covering the full
+     * host physical range owned by that node.  This is critical because
+     * PVH dom0's guest E820 mirrors the host layout (Linux sees all host
+     * RAM regions even though only ~dom0_mem worth are actually populated),
+     * and Linux's NUMA validator (numa_register_memblks) compares its e820
+     * RAM view against SRAT memory affinity coverage.  Anything less than
+     * full coverage triggers the "no nodes coverage" rejection and falls
+     * back to a faked single-node layout.
+     *
+     * Per-memblk ownership is also the source of truth for our per-page
+     * MEMF_node binding (via dom0_gpa_to_pnode), so using memblks here
+     * keeps SRAT and memory placement consistent.
+     */
+    {
+        unsigned int k, nr_memblks = numa_get_nr_memblks();
+        paddr_t mstart, mend;
+        nodeid_t mnid;
+
+        for ( k = 0; k < nr_memblks; k++ )
+        {
+            if ( !numa_get_memblk(k, &mstart, &mend, &mnid) )
+                break;
+            if ( !nodemask_test(mnid, &used_nodes) )
+                continue;
+            nr_vmemranges++;
+        }
+    }
 
     if ( nr_vmemranges == 0 )
     {
         printk(XENLOG_WARNING
-               "%pd: no E820 RAM regions; skipping vNUMA setup\n", d);
+               "%pd: no NUMA memblks for vnode nodes; "
+               "skipping vNUMA setup\n", d);
         return 0;
     }
 
@@ -1744,37 +1770,36 @@ static int __init dom0_setup_vnuma(struct domain *d)
                 __node_distance(pnodes[i], pnodes[j]);
 
     /*
-     * vmemranges: split each E820 RAM region equally across vnodes.  Each
-     * vnode has the same proportional share of the host's physical CPUs
-     * (1:1 vCPU/pCPU pinning, dom0 vCPU count == pCPU count), so equal
-     * memory share is the natural choice.
-     *
-     * The last vnode's chunk absorbs any rounding remainder so the union
-     * of vmemrange entries exactly covers the original E820 RAM region.
+     * Build vmemranges from physical NUMA memblks, second pass.  Each
+     * emitted vmemrange covers one host node's contiguous physical range;
+     * nid is the dense vnode index that maps to that pnode.  Iteration
+     * order matches the counting pass above so range_idx ends at
+     * nr_vmemranges.
      */
     range_idx = 0;
-    for ( i = 0; i < d->arch.nr_e820; i++ )
     {
-        uint64_t base, size, chunk;
+        unsigned int k, nr_memblks = numa_get_nr_memblks();
+        paddr_t mstart, mend;
+        nodeid_t mnid;
 
-        if ( d->arch.e820[i].type != E820_RAM )
-            continue;
-
-        base = d->arch.e820[i].addr;
-        size = d->arch.e820[i].size;
-        /* Page-align per-vnode chunk to keep vmemrange boundaries clean. */
-        chunk = (size / nr_vnodes) & ~(PAGE_SIZE - 1);
-
-        for ( j = 0; j < nr_vnodes; j++ )
+        for ( k = 0; k < nr_memblks; k++ )
         {
-            uint64_t start = base + j * chunk;
-            uint64_t end = (j == nr_vnodes - 1) ? base + size
-                                                : start + chunk;
+            unsigned int vnode;
 
-            vnuma->vmemrange[range_idx].start = start;
-            vnuma->vmemrange[range_idx].end = end;
+            if ( !numa_get_memblk(k, &mstart, &mend, &mnid) )
+                break;
+            if ( !nodemask_test(mnid, &used_nodes) )
+                continue;
+
+            for ( vnode = 0; vnode < nr_vnodes; vnode++ )
+                if ( pnodes[vnode] == mnid )
+                    break;
+            ASSERT(vnode < nr_vnodes);
+
+            vnuma->vmemrange[range_idx].start = mstart;
+            vnuma->vmemrange[range_idx].end = mend;
             vnuma->vmemrange[range_idx].flags = 0;
-            vnuma->vmemrange[range_idx].nid = j;
+            vnuma->vmemrange[range_idx].nid = vnode;
             range_idx++;
         }
     }

--- a/xen/arch/x86/hvm/dom0_build.c
+++ b/xen/arch/x86/hvm/dom0_build.c
@@ -398,74 +398,134 @@ static __init void pvh_setup_e820(struct domain *d, unsigned long nr_pages)
 {
     struct e820entry *entry, *entry_guest;
     unsigned int i;
-    unsigned long pages, cur_pages = 0;
+    unsigned long total_ram_pages = 0, cur_pages = 0, seen_pages = 0;
     uint64_t start, end;
 
     /*
-     * Craft the e820 memory map for Dom0 based on the hardware e820 map.
-     * Add an extra entry in case we have to split a RAM entry into a RAM and a
-     * UNUSABLE one in order to truncate it.
+     * Pass 1: sum the host's E820_RAM (page-aligned, the same way pass 2
+     * computes per-region size).  Used in pass 2 to distribute nr_pages
+     * across RAM regions proportionally to each region's size.
+     *
+     * Without this, the old "fill regions in address order until nr_pages
+     * is reached, mark the rest UNUSABLE" logic piled all of dom0's RAM
+     * onto whichever physical NUMA nodes own the lowest physical addresses.
+     * On a multi-socket host that meant dom0 ran with 0 bytes of memory on
+     * most of its nodes -- the per-node MEMF_node bindings in
+     * pvh_populate_memory_range() worked correctly but had no high-address
+     * RAM regions to populate, since pvh_setup_e820() had already turned
+     * them into UNUSABLE.
      */
-    d->arch.e820 = xzalloc_array(struct e820entry, e820.nr_map + 1);
-    if ( !d->arch.e820 )
-        panic("Unable to allocate memory for Dom0 e820 map\n");
-    entry_guest = d->arch.e820;
-
-    /* Clamp e820 memory map to match the memory assigned to Dom0 */
     for ( i = 0, entry = e820.map; i < e820.nr_map; i++, entry++ )
     {
-        *entry_guest = *entry;
-
         if ( entry->type != E820_RAM )
-            goto next;
+            continue;
 
-        if ( nr_pages == cur_pages )
-        {
-            /*
-             * We already have all the requested memory, turn this RAM region
-             * into a UNUSABLE region in order to prevent Dom0 from placing
-             * BARs in this area.
-             */
-            entry_guest->type = E820_UNUSABLE;
-            goto next;
-        }
-
-        /*
-         * Make sure the start and length are aligned to PAGE_SIZE, because
-         * that's the minimum granularity of the 2nd stage translation. Since
-         * the p2m code uses PAGE_ORDER_4K internally, also use it here in
-         * order to prevent this code from getting out of sync.
-         */
         start = ROUNDUP(entry->addr, PAGE_SIZE << PAGE_ORDER_4K);
         end = (entry->addr + entry->size) &
               ~((PAGE_SIZE << PAGE_ORDER_4K) - 1);
         if ( start >= end )
             continue;
 
-        entry_guest->type = E820_RAM;
+        total_ram_pages += PFN_DOWN(end - start);
+    }
+
+    if ( total_ram_pages == 0 )
+        panic("Host E820 has no usable RAM\n");
+
+    if ( nr_pages > total_ram_pages )
+        nr_pages = total_ram_pages;
+
+    /*
+     * Worst case each RAM region splits into RAM + UNUSABLE; non-RAM
+     * entries pass through unchanged.  Bound the allocation accordingly.
+     */
+    d->arch.e820 = xzalloc_array(struct e820entry, e820.nr_map * 2);
+    if ( !d->arch.e820 )
+        panic("Unable to allocate memory for Dom0 e820 map\n");
+    entry_guest = d->arch.e820;
+
+    /*
+     * Pass 2: copy each E820 entry.  For RAM entries, compute the
+     * proportional keep amount via Bresenham-style remainder accumulation
+     * (target_for_this_and_all_prior - already_kept) so per-region
+     * rounding never drifts -- the final RAM region's keep absorbs any
+     * leftover so cur_pages == nr_pages at the end.
+     */
+    for ( i = 0, entry = e820.map; i < e820.nr_map; i++, entry++ )
+    {
+        unsigned long region_pages, target, keep;
+
+        *entry_guest = *entry;
+
+        if ( entry->type != E820_RAM )
+            goto next;
+
+        start = ROUNDUP(entry->addr, PAGE_SIZE << PAGE_ORDER_4K);
+        end = (entry->addr + entry->size) &
+              ~((PAGE_SIZE << PAGE_ORDER_4K) - 1);
+        if ( start >= end )
+        {
+            /*
+             * Sub-page RAM entry: cannot be granted as RAM (the p2m works
+             * at PAGE_ORDER_4K).  Mark UNUSABLE rather than RAM so dom0
+             * doesn't try to use it, while still preserving the address
+             * layout of the original e820.
+             */
+            entry_guest->type = E820_UNUSABLE;
+            goto next;
+        }
+
         entry_guest->addr = start;
         entry_guest->size = end - start;
-        pages = PFN_DOWN(entry_guest->size);
-        if ( (cur_pages + pages) > nr_pages )
+        region_pages = PFN_DOWN(end - start);
+        seen_pages += region_pages;
+
+        /*
+         * Proportional target: by the end of this region, we should have
+         * kept floor(seen_pages * nr_pages / total_ram_pages) RAM pages
+         * total.  Subtract what we've already kept to get this region's
+         * share.  Use a 128-bit-style mulhi via uint64_t to avoid overflow
+         * on hosts with terabytes of RAM (seen_pages * nr_pages can
+         * exceed 2^64 in 32-bit math).
+         */
+        target = (uint64_t)seen_pages * nr_pages / total_ram_pages;
+        keep = target - cur_pages;
+        cur_pages = target;
+
+        if ( keep > region_pages )
+            keep = region_pages;  /* defensive clamp; shouldn't trip */
+
+        if ( keep == 0 )
         {
-            /* Truncate region */
-            entry_guest->size = (nr_pages - cur_pages) << PAGE_SHIFT;
-            /* Add the remaining of the RAM region as UNUSABLE. */
+            /*
+             * This whole region is trimmed away.  Mark UNUSABLE so dom0
+             * doesn't place BARs here.
+             */
+            entry_guest->type = E820_UNUSABLE;
+            goto next;
+        }
+
+        entry_guest->type = E820_RAM;
+        entry_guest->size = (uint64_t)keep << PAGE_SHIFT;
+
+        if ( keep < region_pages )
+        {
+            /*
+             * Region split: emit the kept RAM prefix and follow it with
+             * an UNUSABLE remainder so the address layout is unchanged
+             * but dom0 won't try to use those pages as RAM.
+             */
             entry_guest++;
             d->arch.nr_e820++;
             entry_guest->type = E820_UNUSABLE;
-            entry_guest->addr = start + ((nr_pages - cur_pages) << PAGE_SHIFT);
+            entry_guest->addr = start + ((uint64_t)keep << PAGE_SHIFT);
             entry_guest->size = end - entry_guest->addr;
-            cur_pages = nr_pages;
         }
-        else
-        {
-            cur_pages += pages;
-        }
+
  next:
         d->arch.nr_e820++;
         entry_guest++;
-        ASSERT(d->arch.nr_e820 <= e820.nr_map + 1);
+        ASSERT(d->arch.nr_e820 <= e820.nr_map * 2);
     }
     ASSERT(cur_pages == nr_pages);
 }

--- a/xen/arch/x86/hvm/dom0_build.c
+++ b/xen/arch/x86/hvm/dom0_build.c
@@ -1121,6 +1121,102 @@ static int __init pvh_setup_acpi_srat(struct domain *d, paddr_t *addr)
     return rc;
 }
 
+/*
+ * Build a System Locality Distance Information Table from d->vnuma's
+ * vdistance matrix.  Returns 0 on success with *addr set to the SLIT's
+ * guest physical address, or 0 with *addr = 0 when dom0 has no vNUMA
+ * topology (single-node host, detection gate unmet, etc.) and we should
+ * skip SLIT entirely.
+ *
+ * SLIT body is a square matrix of u8 distances indexed [i*N + j] where
+ * N = nr_vnodes.  Distances follow the ACPI SLIT convention: 10 = local,
+ * 11..253 = remote (larger means farther), 254 = unreachable, 255 = reserved.
+ *
+ * Without a SLIT, Linux uses a default distance matrix (10 local /
+ * 20 remote) regardless of actual host topology.  Emitting one lets the
+ * dom0 kernel make better-informed NUMA scheduling decisions.
+ */
+static int __init pvh_setup_acpi_slit(struct domain *d, paddr_t *addr)
+{
+    struct acpi_table_slit *slit;
+    const struct vnuma_info *vnuma;
+    unsigned long size;
+    unsigned int i, j, n;
+    int rc;
+
+    *addr = 0;
+
+    read_lock(&d->vnuma_rwlock);
+    vnuma = d->vnuma;
+    if ( !vnuma || vnuma->nr_vnodes <= 1 )
+    {
+        read_unlock(&d->vnuma_rwlock);
+        return 0;
+    }
+
+    n = vnuma->nr_vnodes;
+
+    /*
+     * struct acpi_table_slit declares entry[1]; the real allocation must
+     * be sized for n*n entries.  Subtract the one entry already counted.
+     */
+    size = sizeof(*slit) + (n * n - 1) * sizeof(slit->entry[0]);
+
+    slit = xzalloc_bytes(size);
+    if ( !slit )
+    {
+        read_unlock(&d->vnuma_rwlock);
+        printk("Unable to allocate memory for SLIT table\n");
+        return -ENOMEM;
+    }
+
+    memcpy(slit->header.signature, ACPI_SIG_SLIT, ACPI_NAME_SIZE);
+    slit->header.revision = 1;
+    safe_strcpy(slit->header.oem_id, "Xen");
+    safe_strcpy(slit->header.oem_table_id, "HVM");
+    slit->header.oem_revision = 0;
+    safe_strcpy(slit->header.asl_compiler_id, "XEN");
+    slit->header.asl_compiler_revision = 0;
+    slit->locality_count = n;
+
+    for ( i = 0; i < n; i++ )
+        for ( j = 0; j < n; j++ )
+        {
+            unsigned int d_ij = vnuma->vdistance[i * n + j];
+
+            /* SLIT entries are u8; clamp at 254 (255 is reserved). */
+            slit->entry[i * n + j] = d_ij > 254 ? 254 : d_ij;
+        }
+
+    read_unlock(&d->vnuma_rwlock);
+
+    slit->header.length = size;
+    slit->header.checksum -= acpi_tb_checksum(ACPI_CAST_PTR(u8, slit), size);
+
+    if ( pvh_steal_ram(d, size, 0, GB(4), addr) )
+    {
+        printk("Unable to steal guest RAM for SLIT\n");
+        rc = -ENOMEM;
+        goto out;
+    }
+
+    if ( pvh_add_mem_range(d, *addr, *addr + size, E820_ACPI) )
+        printk("Unable to add SLIT region to memory map\n");
+
+    rc = hvm_copy_to_guest_phys(*addr, slit, size, d->vcpu[0]);
+    if ( rc )
+    {
+        printk("Unable to copy SLIT into guest memory\n");
+        goto out;
+    }
+
+    rc = 0;
+
+ out:
+    xfree(slit);
+    return rc;
+}
+
 static bool __init acpi_memory_banned(unsigned long address,
                                       unsigned long size)
 {
@@ -1187,7 +1283,8 @@ static bool __init pvh_acpi_xsdt_table_allowed(const char *sig,
 }
 
 static int __init pvh_setup_acpi_xsdt(struct domain *d, paddr_t madt_addr,
-                                      paddr_t srat_addr, paddr_t *addr)
+                                      paddr_t srat_addr, paddr_t slit_addr,
+                                      paddr_t *addr)
 {
     struct acpi_table_xsdt *xsdt;
     struct acpi_table_header *table;
@@ -1195,8 +1292,8 @@ static int __init pvh_setup_acpi_xsdt(struct domain *d, paddr_t madt_addr,
     const struct acpi_table_desc *tables = acpi_gbl_root_table_list.tables;
     unsigned long size = sizeof(*xsdt);
     unsigned int i, j, num_tables = 0;
-    /* MADT is always present; SRAT only when vNUMA is active. */
-    unsigned int extra_tables = 1 + (srat_addr ? 1 : 0);
+    /* MADT is always present; SRAT and SLIT only when vNUMA is active. */
+    unsigned int extra_tables = 1 + (srat_addr ? 1 : 0) + (slit_addr ? 1 : 0);
     paddr_t xsdt_paddr;
     int rc;
 
@@ -1272,9 +1369,11 @@ static int __init pvh_setup_acpi_xsdt(struct domain *d, paddr_t madt_addr,
     j = 0;
     xsdt->table_offset_entry[j++] = madt_addr;
 
-    /* Add the custom SRAT when dom0 has a vNUMA topology installed. */
+    /* Add the custom SRAT and SLIT when dom0 has a vNUMA topology. */
     if ( srat_addr )
         xsdt->table_offset_entry[j++] = srat_addr;
+    if ( slit_addr )
+        xsdt->table_offset_entry[j++] = slit_addr;
 
     /* Copy the addresses of the rest of the allowed tables. */
     for( i = 0; i < acpi_gbl_root_table_list.count; i++ )
@@ -1322,7 +1421,7 @@ static int __init pvh_setup_acpi_xsdt(struct domain *d, paddr_t madt_addr,
 static int __init pvh_setup_acpi(struct domain *d, paddr_t start_info)
 {
     unsigned long pfn, nr_pages;
-    paddr_t madt_paddr, srat_paddr, xsdt_paddr, rsdp_paddr;
+    paddr_t madt_paddr, srat_paddr, slit_paddr, xsdt_paddr, rsdp_paddr;
     unsigned int i;
     int rc;
     struct acpi_table_rsdp *native_rsdp, rsdp = {
@@ -1389,7 +1488,12 @@ static int __init pvh_setup_acpi(struct domain *d, paddr_t start_info)
     if ( rc )
         return rc;
 
-    rc = pvh_setup_acpi_xsdt(d, madt_paddr, srat_paddr, &xsdt_paddr);
+    rc = pvh_setup_acpi_slit(d, &slit_paddr);
+    if ( rc )
+        return rc;
+
+    rc = pvh_setup_acpi_xsdt(d, madt_paddr, srat_paddr, slit_paddr,
+                             &xsdt_paddr);
     if ( rc )
         return rc;
 

--- a/xen/arch/x86/hvm/dom0_build.c
+++ b/xen/arch/x86/hvm/dom0_build.c
@@ -8,9 +8,13 @@
  */
 
 #include <xen/acpi.h>
+#include <xen/domain.h>
+#include <xen/err.h>
 #include <xen/init.h>
 #include <xen/libelf.h>
 #include <xen/multiboot.h>
+#include <xen/nodemask.h>
+#include <xen/numa.h>
 #include <xen/pci.h>
 #include <xen/softirq.h>
 
@@ -1328,6 +1332,169 @@ static void __hwdom_init pvh_setup_mmcfg(struct domain *d)
     }
 }
 
+/*
+ * Compute and install a vNUMA layout for dom0 derived from the host's
+ * physical NUMA topology.  Only runs when dom0_vnuma_enabled() (in
+ * arch/x86/dom0_build.c) set XEN_DOMCTL_CDF_vnuma_apic_topology on
+ * dom0; otherwise it is a no-op.
+ *
+ * Under the supported constraints (PVH dom0, hard 1:1 vCPU pinning, dom0
+ * vCPU count == pCPU count), each dom0 vCPU N is pinned to pCPU N, so
+ * the per-vCPU vnode assignment is exactly cpu_to_node(N).  The set of
+ * vnodes is the set of physical nodes the host has — no layout decisions
+ * to make.
+ *
+ * Must run AFTER pvh_setup_e820() (called from pvh_init_p2m) because we
+ * read d->arch.e820 to size and place vmemrange entries.  Must run
+ * BEFORE pvh_setup_acpi() because the MADT, SRAT and SLIT generation
+ * that runs there will source per-vCPU APIC IDs and per-node memory
+ * ranges from the vNUMA state we install here.
+ */
+static int __init dom0_setup_vnuma(struct domain *d)
+{
+    struct vnuma_info *vnuma;
+    nodeid_t pnodes[MAX_NUMNODES];
+    nodemask_t used_nodes;
+    unsigned int nr_vnodes, nr_vmemranges = 0, range_idx, i, j;
+    nodeid_t node;
+
+    if ( !(d->options & XEN_DOMCTL_CDF_vnuma_apic_topology) )
+        return 0;
+
+    if ( !d->max_vcpus )
+        return -EINVAL;
+
+    /*
+     * Discover the set of physical nodes dom0's pinned vCPUs span.  With
+     * dom0_vcpus_pin=1 and dom0_max_vcpus == num_present_cpus(), vCPU N
+     * is pinned to pCPU N, so cpu_to_node(N) gives the host NUMA node
+     * that hosts this vCPU.
+     */
+    nodes_clear(used_nodes);
+    for ( i = 0; i < d->max_vcpus; i++ )
+    {
+        node = cpu_to_node(i);
+        if ( node != NUMA_NO_NODE )
+            node_set(node, used_nodes);
+    }
+
+    nr_vnodes = nodes_weight(used_nodes);
+    if ( nr_vnodes <= 1 )
+        return 0;  /* Single-node host or all CPUs on one node — no vNUMA. */
+
+    /*
+     * Build dense vnode index → physical node ID mapping.  Iteration over
+     * used_nodes yields nodes in ascending order, so vnode 0 corresponds
+     * to the lowest-numbered physical node dom0 spans, and so on.
+     */
+    i = 0;
+    for_each_node_mask ( node, used_nodes )
+        pnodes[i++] = node;
+
+    /* One vmemrange per (E820 RAM region, vnode) pair. */
+    for ( i = 0; i < d->arch.nr_e820; i++ )
+        if ( d->arch.e820[i].type == E820_RAM )
+            nr_vmemranges += nr_vnodes;
+
+    if ( nr_vmemranges == 0 )
+    {
+        printk(XENLOG_WARNING
+               "%pd: no E820 RAM regions; skipping vNUMA setup\n", d);
+        return 0;
+    }
+
+    vnuma = vnuma_alloc(nr_vnodes, nr_vmemranges, d->max_vcpus);
+    if ( IS_ERR(vnuma) )
+        return PTR_ERR(vnuma);
+
+    vnuma->nr_vnodes = nr_vnodes;
+    vnuma->nr_vmemranges = nr_vmemranges;
+
+    /* vnode → pnode mapping. */
+    for ( i = 0; i < nr_vnodes; i++ )
+        vnuma->vnode_to_pnode[i] = pnodes[i];
+
+    /* vCPU → vnode mapping via cpu_to_node. */
+    for ( i = 0; i < d->max_vcpus; i++ )
+    {
+        nodeid_t cpu_node = cpu_to_node(i);
+
+        for ( j = 0; j < nr_vnodes; j++ )
+            if ( pnodes[j] == cpu_node )
+            {
+                vnuma->vcpu_to_vnode[i] = j;
+                break;
+            }
+    }
+
+    /* SLIT: mirror the host SLIT for the nodes we use. */
+    for ( i = 0; i < nr_vnodes; i++ )
+        for ( j = 0; j < nr_vnodes; j++ )
+            vnuma->vdistance[i * nr_vnodes + j] =
+                __node_distance(pnodes[i], pnodes[j]);
+
+    /*
+     * vmemranges: split each E820 RAM region equally across vnodes.  Each
+     * vnode has the same proportional share of the host's physical CPUs
+     * (1:1 vCPU/pCPU pinning, dom0 vCPU count == pCPU count), so equal
+     * memory share is the natural choice.
+     *
+     * The last vnode's chunk absorbs any rounding remainder so the union
+     * of vmemrange entries exactly covers the original E820 RAM region.
+     */
+    range_idx = 0;
+    for ( i = 0; i < d->arch.nr_e820; i++ )
+    {
+        uint64_t base, size, chunk;
+
+        if ( d->arch.e820[i].type != E820_RAM )
+            continue;
+
+        base = d->arch.e820[i].addr;
+        size = d->arch.e820[i].size;
+        /* Page-align per-vnode chunk to keep vmemrange boundaries clean. */
+        chunk = (size / nr_vnodes) & ~(PAGE_SIZE - 1);
+
+        for ( j = 0; j < nr_vnodes; j++ )
+        {
+            uint64_t start = base + j * chunk;
+            uint64_t end = (j == nr_vnodes - 1) ? base + size
+                                                : start + chunk;
+
+            vnuma->vmemrange[range_idx].start = start;
+            vnuma->vmemrange[range_idx].end = end;
+            vnuma->vmemrange[range_idx].flags = 0;
+            vnuma->vmemrange[range_idx].nid = j;
+            range_idx++;
+        }
+    }
+    ASSERT(range_idx == nr_vmemranges);
+
+    write_lock(&d->vnuma_rwlock);
+    vnuma_destroy(d->vnuma);
+    d->vnuma = vnuma;
+    write_unlock(&d->vnuma_rwlock);
+
+    /*
+     * Recalculate CPUID topology now that d->vnuma is populated.  This
+     * also refreshes per-vCPU vlapic APIC IDs via vlapic_reinit_apic_id().
+     * Init dom0 cpuid policy ran much earlier (setup.c:init_dom0_cpuid_policy)
+     * with empty d->vnuma; the recalc overwrites those values with the
+     * vNUMA-aware ones.
+     */
+    arch_domain_update_vnuma(d);
+
+    if ( opt_dom0_verbose )
+    {
+        printk(XENLOG_INFO "%pd vNUMA: %u vnodes\n", d, nr_vnodes);
+        for ( i = 0; i < nr_vnodes; i++ )
+            printk(XENLOG_INFO "  vnode %u -> pnode %u\n",
+                   i, vnuma->vnode_to_pnode[i]);
+    }
+
+    return 0;
+}
+
 int __init dom0_construct_pvh(const struct boot_domain *bd)
 {
     paddr_t entry, start_info;
@@ -1366,6 +1533,19 @@ int __init dom0_construct_pvh(const struct boot_domain *bd)
      * will likely add mappings required by devices to the p2m (ie: RMRRs).
      */
     pvh_init_p2m(d);
+
+    /*
+     * Install dom0's vNUMA layout now that the E820 map is built but before
+     * memory is allocated.  pvh_populate_p2m() consumes it to drive per-node
+     * memory allocation; pvh_setup_acpi() consumes it to generate
+     * MADT/SRAT/SLIT.
+     */
+    rc = dom0_setup_vnuma(d);
+    if ( rc )
+    {
+        printk("Failed to setup Dom0 vNUMA: %d\n", rc);
+        return rc;
+    }
 
     iommu_hwdom_init(d);
 

--- a/xen/arch/x86/hvm/dom0_build.c
+++ b/xen/arch/x86/hvm/dom0_build.c
@@ -17,6 +17,7 @@
 #include <xen/numa.h>
 #include <xen/pci.h>
 #include <xen/softirq.h>
+#include <xen/string.h>
 
 #include <acpi/actables.h>
 
@@ -1002,6 +1003,124 @@ static int __init pvh_setup_acpi_madt(struct domain *d, paddr_t *addr)
     return rc;
 }
 
+/*
+ * Build a System Resource Affinity Table reflecting d->vnuma and write it
+ * into guest memory.  Returns 0 on success with *addr set to the SRAT's
+ * guest physical address, or 0 with *addr = 0 when dom0 has no vNUMA
+ * topology (single-node host, detection gate unmet, etc.) and we should
+ * skip SRAT entirely.
+ *
+ * SRAT body:
+ *   - One Processor Local x2APIC Affinity entry per vCPU
+ *     (proximity_domain = vcpu_to_vnode[i], apic_id from guest_vcpu_x2apic_id)
+ *   - One Memory Affinity entry per vnuma->vmemrange[]
+ *     (proximity_domain = range->nid, base_address/length from range)
+ *
+ * The proximity_domain values are vnode indices; Linux uses them to build
+ * its NUMA node map and to cross-reference processor and memory affinity.
+ */
+static int __init pvh_setup_acpi_srat(struct domain *d, paddr_t *addr)
+{
+    struct acpi_table_srat *srat;
+    struct acpi_srat_x2apic_cpu_affinity *x2apic;
+    struct acpi_srat_mem_affinity *mem;
+    const struct vnuma_info *vnuma;
+    unsigned long size;
+    unsigned int i;
+    int rc;
+
+    *addr = 0;
+
+    read_lock(&d->vnuma_rwlock);
+    vnuma = d->vnuma;
+    if ( !vnuma || vnuma->nr_vnodes <= 1 )
+    {
+        read_unlock(&d->vnuma_rwlock);
+        return 0;
+    }
+
+    size = sizeof(*srat);
+    size += sizeof(*x2apic) * d->max_vcpus;
+    size += sizeof(*mem) * vnuma->nr_vmemranges;
+
+    srat = xzalloc_bytes(size);
+    if ( !srat )
+    {
+        read_unlock(&d->vnuma_rwlock);
+        printk("Unable to allocate memory for SRAT table\n");
+        return -ENOMEM;
+    }
+
+    memcpy(srat->header.signature, ACPI_SIG_SRAT, ACPI_NAME_SIZE);
+    srat->header.revision = 3;
+    /* OEM fields match the style used by the custom MADT we build. */
+    safe_strcpy(srat->header.oem_id, "Xen");
+    safe_strcpy(srat->header.oem_table_id, "HVM");
+    srat->header.oem_revision = 0;
+    safe_strcpy(srat->header.asl_compiler_id, "XEN");
+    srat->header.asl_compiler_revision = 0;
+    srat->table_revision = 1;
+
+    x2apic = (void *)(srat + 1);
+    for ( i = 0; i < d->max_vcpus; i++ )
+    {
+        x2apic->header.type = ACPI_SRAT_TYPE_X2APIC_CPU_AFFINITY;
+        x2apic->header.length = sizeof(*x2apic);
+        x2apic->proximity_domain = vnuma->vcpu_to_vnode[i];
+        x2apic->apic_id = guest_vcpu_x2apic_id(d, i);
+        x2apic->flags = ACPI_SRAT_CPU_ENABLED;
+        x2apic++;
+    }
+
+    mem = (void *)x2apic;
+    for ( i = 0; i < vnuma->nr_vmemranges; i++ )
+    {
+        const struct xen_vmemrange *range = &vnuma->vmemrange[i];
+
+        mem->header.type = ACPI_SRAT_TYPE_MEMORY_AFFINITY;
+        mem->header.length = sizeof(*mem);
+        mem->proximity_domain = range->nid;
+        mem->base_address = range->start;
+        mem->length = range->end - range->start;
+        mem->flags = ACPI_SRAT_MEM_ENABLED;
+        mem++;
+    }
+
+    read_unlock(&d->vnuma_rwlock);
+
+    ASSERT(((void *)mem - (void *)srat) == size);
+    srat->header.length = size;
+    /*
+     * Calling acpi_tb_checksum here is a layering violation, but mirrors
+     * what pvh_setup_acpi_madt() does -- introducing a wrapper for such
+     * simple usage seems overkill.
+     */
+    srat->header.checksum -= acpi_tb_checksum(ACPI_CAST_PTR(u8, srat), size);
+
+    if ( pvh_steal_ram(d, size, 0, GB(4), addr) )
+    {
+        printk("Unable to steal guest RAM for SRAT\n");
+        rc = -ENOMEM;
+        goto out;
+    }
+
+    if ( pvh_add_mem_range(d, *addr, *addr + size, E820_ACPI) )
+        printk("Unable to add SRAT region to memory map\n");
+
+    rc = hvm_copy_to_guest_phys(*addr, srat, size, d->vcpu[0]);
+    if ( rc )
+    {
+        printk("Unable to copy SRAT into guest memory\n");
+        goto out;
+    }
+
+    rc = 0;
+
+ out:
+    xfree(srat);
+    return rc;
+}
+
 static bool __init acpi_memory_banned(unsigned long address,
                                       unsigned long size)
 {
@@ -1068,7 +1187,7 @@ static bool __init pvh_acpi_xsdt_table_allowed(const char *sig,
 }
 
 static int __init pvh_setup_acpi_xsdt(struct domain *d, paddr_t madt_addr,
-                                      paddr_t *addr)
+                                      paddr_t srat_addr, paddr_t *addr)
 {
     struct acpi_table_xsdt *xsdt;
     struct acpi_table_header *table;
@@ -1076,6 +1195,8 @@ static int __init pvh_setup_acpi_xsdt(struct domain *d, paddr_t madt_addr,
     const struct acpi_table_desc *tables = acpi_gbl_root_table_list.tables;
     unsigned long size = sizeof(*xsdt);
     unsigned int i, j, num_tables = 0;
+    /* MADT is always present; SRAT only when vNUMA is active. */
+    unsigned int extra_tables = 1 + (srat_addr ? 1 : 0);
     paddr_t xsdt_paddr;
     int rc;
 
@@ -1095,11 +1216,14 @@ static int __init pvh_setup_acpi_xsdt(struct domain *d, paddr_t madt_addr,
     }
 
     /*
-     * No need to add or subtract anything because struct acpi_table_xsdt
-     * includes one array slot already, and we have filtered out the original
-     * MADT and we are going to add a custom built MADT.
+     * struct acpi_table_xsdt includes one array slot already.  That slot
+     * accommodates our custom MADT (which replaces the filtered native
+     * MADT, keeping the count balanced).  Any additional Xen-generated
+     * tables (e.g. SRAT when dom0 vNUMA is active) need extra slots beyond
+     * the one already included in struct acpi_table_xsdt.
      */
     size += num_tables * sizeof(xsdt->table_offset_entry[0]);
+    size += (extra_tables - 1) * sizeof(xsdt->table_offset_entry[0]);
 
     xsdt = xzalloc_bytes(size);
     if ( !xsdt )
@@ -1144,11 +1268,16 @@ static int __init pvh_setup_acpi_xsdt(struct domain *d, paddr_t madt_addr,
      */
     xsdt->header.signature[0] = 'X';
 
-    /* Add the custom MADT. */
-    xsdt->table_offset_entry[0] = madt_addr;
+    /* Add the custom MADT (always present). */
+    j = 0;
+    xsdt->table_offset_entry[j++] = madt_addr;
+
+    /* Add the custom SRAT when dom0 has a vNUMA topology installed. */
+    if ( srat_addr )
+        xsdt->table_offset_entry[j++] = srat_addr;
 
     /* Copy the addresses of the rest of the allowed tables. */
-    for( i = 0, j = 1; i < acpi_gbl_root_table_list.count; i++ )
+    for( i = 0; i < acpi_gbl_root_table_list.count; i++ )
     {
         if ( pvh_acpi_xsdt_table_allowed(tables[i].signature.ascii,
                                          tables[i].address, tables[i].length) )
@@ -1193,7 +1322,7 @@ static int __init pvh_setup_acpi_xsdt(struct domain *d, paddr_t madt_addr,
 static int __init pvh_setup_acpi(struct domain *d, paddr_t start_info)
 {
     unsigned long pfn, nr_pages;
-    paddr_t madt_paddr, xsdt_paddr, rsdp_paddr;
+    paddr_t madt_paddr, srat_paddr, xsdt_paddr, rsdp_paddr;
     unsigned int i;
     int rc;
     struct acpi_table_rsdp *native_rsdp, rsdp = {
@@ -1256,7 +1385,11 @@ static int __init pvh_setup_acpi(struct domain *d, paddr_t start_info)
     if ( rc )
         return rc;
 
-    rc = pvh_setup_acpi_xsdt(d, madt_paddr, &xsdt_paddr);
+    rc = pvh_setup_acpi_srat(d, &srat_paddr);
+    if ( rc )
+        return rc;
+
+    rc = pvh_setup_acpi_xsdt(d, madt_paddr, srat_paddr, &xsdt_paddr);
     if ( rc )
         return rc;
 

--- a/xen/arch/x86/hvm/dom0_build.c
+++ b/xen/arch/x86/hvm/dom0_build.c
@@ -1665,7 +1665,7 @@ static int __init dom0_setup_vnuma(struct domain *d)
     struct vnuma_info *vnuma;
     nodeid_t pnodes[MAX_NUMNODES];
     nodemask_t used_nodes;
-    unsigned int nr_vnodes, nr_vmemranges = 0, range_idx, i, j;
+    unsigned int nr_vnodes, nr_vmemranges = 0, range_idx, i, j, max_pxm = 0;
     nodeid_t node;
 
     if ( !(d->options & XEN_DOMCTL_CDF_vnuma_apic_topology) )
@@ -1688,18 +1688,46 @@ static int __init dom0_setup_vnuma(struct domain *d)
             node_set(node, used_nodes);
     }
 
-    nr_vnodes = nodes_weight(used_nodes);
-    if ( nr_vnodes <= 1 )
+    if ( nodes_weight(used_nodes) <= 1 )
         return 0;  /* Single-node host or all CPUs on one node — no vNUMA. */
 
     /*
-     * Build dense vnode index → physical node ID mapping.  Iteration over
-     * used_nodes yields nodes in ascending order, so vnode 0 corresponds
-     * to the lowest-numbered physical node dom0 spans, and so on.
+     * Build pnodes[] indexed by host PXM (ACPI proximity domain), not by
+     * a dense Xen-internal vnode id.  Xen renumbers PXMs in SRAT memory-
+     * table order during boot (PXM 1 may become Xen node 3, etc.), so a
+     * dense-vnode SRAT would advertise socket numbers that are a permutation
+     * of the host's firmware-assigned proximity numbering -- "numactl -N 1"
+     * in dom0 would land on the wrong physical socket, "lscpu" would
+     * disagree with the host, and any tooling that compares dom0's view
+     * with the host's would be confused.
+     *
+     * Using PXM as the vnode index makes vcpu_to_vnode/vmemrange.nid
+     * directly meaningful to anything reading /proc/cpuinfo or SRAT, with
+     * no further translation needed in cpuid.c or pvh_setup_acpi_srat.
+     * vnode_to_pnode[PXM] still stores the Xen internal node id (needed
+     * for SLIT __node_distance and MEMF_node), so the internal allocation
+     * path is unchanged.  Unused PXM slots (gaps in firmware numbering)
+     * stay NUMA_NO_NODE and represent empty vnodes -- Linux treats those
+     * as offline proximity domains, which is the correct behaviour.
      */
-    i = 0;
+    for ( i = 0; i < ARRAY_SIZE(pnodes); i++ )
+        pnodes[i] = NUMA_NO_NODE;
     for_each_node_mask ( node, used_nodes )
-        pnodes[i++] = node;
+    {
+        unsigned int pxm = numa_node_to_arch_nid(node);
+
+        if ( pxm >= ARRAY_SIZE(pnodes) )
+        {
+            printk(XENLOG_WARNING
+                   "%pd: PXM %u >= MAX_NUMNODES; skipping vNUMA setup\n",
+                   d, pxm);
+            return 0;
+        }
+        pnodes[pxm] = node;
+        if ( pxm > max_pxm )
+            max_pxm = pxm;
+    }
+    nr_vnodes = max_pxm + 1;
 
     /*
      * Count vmemranges = number of physical NUMA memblks owned by nodes
@@ -1746,35 +1774,36 @@ static int __init dom0_setup_vnuma(struct domain *d)
     vnuma->nr_vnodes = nr_vnodes;
     vnuma->nr_vmemranges = nr_vmemranges;
 
-    /* vnode → pnode mapping. */
+    /* vnode (= host PXM) → pnode (= Xen internal node id) mapping. */
     for ( i = 0; i < nr_vnodes; i++ )
         vnuma->vnode_to_pnode[i] = pnodes[i];
 
-    /* vCPU → vnode mapping via cpu_to_node. */
+    /* vCPU → vnode (= host PXM of the vCPU's pinned pCPU). */
     for ( i = 0; i < d->max_vcpus; i++ )
-    {
-        nodeid_t cpu_node = cpu_to_node(i);
-
-        for ( j = 0; j < nr_vnodes; j++ )
-            if ( pnodes[j] == cpu_node )
-            {
-                vnuma->vcpu_to_vnode[i] = j;
-                break;
-            }
-    }
-
-    /* SLIT: mirror the host SLIT for the nodes we use. */
-    for ( i = 0; i < nr_vnodes; i++ )
-        for ( j = 0; j < nr_vnodes; j++ )
-            vnuma->vdistance[i * nr_vnodes + j] =
-                __node_distance(pnodes[i], pnodes[j]);
+        vnuma->vcpu_to_vnode[i] = numa_node_to_arch_nid(cpu_to_node(i));
 
     /*
-     * Build vmemranges from physical NUMA memblks, second pass.  Each
-     * emitted vmemrange covers one host node's contiguous physical range;
-     * nid is the dense vnode index that maps to that pnode.  Iteration
-     * order matches the counting pass above so range_idx ends at
-     * nr_vmemranges.
+     * SLIT: distances between vnodes are distances between the host pnodes
+     * each PXM names.  Empty PXM slots (firmware-numbering gaps) get the
+     * standard {10 on diagonal, 20 off-diagonal} placeholder so Linux
+     * doesn't see suspicious zeros for offline proximity domains.
+     */
+    for ( i = 0; i < nr_vnodes; i++ )
+        for ( j = 0; j < nr_vnodes; j++ )
+        {
+            if ( pnodes[i] == NUMA_NO_NODE || pnodes[j] == NUMA_NO_NODE )
+                vnuma->vdistance[i * nr_vnodes + j] = (i == j) ? 10 : 20;
+            else
+                vnuma->vdistance[i * nr_vnodes + j] =
+                    __node_distance(pnodes[i], pnodes[j]);
+        }
+
+    /*
+     * Build vmemranges from physical NUMA memblks (second pass; iteration
+     * matches the counting pass so range_idx ends at nr_vmemranges).  nid
+     * is the host PXM that physically owns the range, used both as the
+     * proximity_domain in our SRAT emission and as the index for the
+     * MEMF_node lookup in dom0_gpa_to_pnode -> vnode_to_pnode[nid].
      */
     range_idx = 0;
     {
@@ -1784,22 +1813,15 @@ static int __init dom0_setup_vnuma(struct domain *d)
 
         for ( k = 0; k < nr_memblks; k++ )
         {
-            unsigned int vnode;
-
             if ( !numa_get_memblk(k, &mstart, &mend, &mnid) )
                 break;
             if ( !nodemask_test(mnid, &used_nodes) )
                 continue;
 
-            for ( vnode = 0; vnode < nr_vnodes; vnode++ )
-                if ( pnodes[vnode] == mnid )
-                    break;
-            ASSERT(vnode < nr_vnodes);
-
             vnuma->vmemrange[range_idx].start = mstart;
             vnuma->vmemrange[range_idx].end = mend;
             vnuma->vmemrange[range_idx].flags = 0;
-            vnuma->vmemrange[range_idx].nid = vnode;
+            vnuma->vmemrange[range_idx].nid = numa_node_to_arch_nid(mnid);
             range_idx++;
         }
     }
@@ -1821,10 +1843,13 @@ static int __init dom0_setup_vnuma(struct domain *d)
 
     if ( opt_dom0_verbose )
     {
-        printk(XENLOG_INFO "%pd vNUMA: %u vnodes\n", d, nr_vnodes);
+        printk(XENLOG_INFO
+               "%pd vNUMA: %u vnodes (indexed by host PXM)\n",
+               d, nr_vnodes);
         for ( i = 0; i < nr_vnodes; i++ )
-            printk(XENLOG_INFO "  vnode %u -> pnode %u\n",
-                   i, vnuma->vnode_to_pnode[i]);
+            if ( pnodes[i] != NUMA_NO_NODE )
+                printk(XENLOG_INFO "  PXM %u -> Xen node %u\n",
+                       i, vnuma->vnode_to_pnode[i]);
     }
 
     return 0;

--- a/xen/arch/x86/hvm/dom0_build.c
+++ b/xen/arch/x86/hvm/dom0_build.c
@@ -92,6 +92,34 @@ static int __init modify_identity_mmio(struct domain *d, unsigned long pfn,
     return rc;
 }
 
+/*
+ * Look up the physical NUMA node that should back a given guest physical
+ * address, based on dom0's vNUMA layout.  Returns NUMA_NO_NODE when there
+ * is no vNUMA topology installed, when node binding has been disabled
+ * after a per-node allocation failure, or when no vmemrange covers the
+ * GPA (shouldn't happen in practice but we don't want to lie).
+ */
+static bool __initdata dom0_vnuma_binding_disabled;
+
+static nodeid_t __init dom0_gpa_to_pnode(const struct domain *d, paddr_t gpa)
+{
+    const struct vnuma_info *vnuma = d->vnuma;
+    unsigned int i;
+
+    if ( dom0_vnuma_binding_disabled || !vnuma )
+        return NUMA_NO_NODE;
+
+    for ( i = 0; i < vnuma->nr_vmemranges; i++ )
+    {
+        const struct xen_vmemrange *r = &vnuma->vmemrange[i];
+
+        if ( gpa >= r->start && gpa < r->end )
+            return vnuma->vnode_to_pnode[r->nid];
+    }
+
+    return NUMA_NO_NODE;
+}
+
 /* Populate a HVM memory range using the biggest possible order. */
 static int __init pvh_populate_memory_range(struct domain *d,
                                             unsigned long start,
@@ -114,6 +142,8 @@ static int __init pvh_populate_memory_range(struct domain *d,
     {
         unsigned int order, j;
         unsigned long end;
+        nodeid_t pnode;
+        unsigned int node_memflags = 0;
 
         /* Search for the largest page size which can fulfil this request. */
         for ( j = 0; j < ARRAY_SIZE(orders); j++ )
@@ -147,9 +177,45 @@ static int __init pvh_populate_memory_range(struct domain *d,
         order = min(order ? order - 1 : 0, max_order);
         /* The order allocated and populated must be aligned to the address. */
         order = min(order, start ? ffsl(start) - 1U : MAX_ORDER + 0U);
-        page = alloc_domheap_pages(d, order, dom0_memflags | MEMF_no_scrub);
+
+        /*
+         * When dom0 has a vNUMA topology, bind this allocation to the
+         * physical node that hosts the vmemrange covering this GPA.
+         * Combined with MEMF_exact_node in dom0_memflags, this is a
+         * strict bind: allocation fails rather than spilling to other
+         * nodes -- which is what we want, because spillover would
+         * silently make the SRAT we just generated lie about where
+         * memory actually lives.  The order==0 fallback below disables
+         * node binding if even strict allocation can't be satisfied,
+         * trading the topology guarantee for the ability to boot at all.
+         */
+        pnode = dom0_gpa_to_pnode(d, (paddr_t)start << PAGE_SHIFT);
+        if ( pnode != NUMA_NO_NODE )
+            node_memflags = MEMF_node(pnode);
+
+        page = alloc_domheap_pages(d, order,
+                                   dom0_memflags | node_memflags |
+                                   MEMF_no_scrub);
         if ( page == NULL )
         {
+            if ( order == 0 && node_memflags )
+            {
+                /*
+                 * Per-node allocation failed.  Disable node binding for
+                 * the remainder of dom0 construction and retry.  This
+                 * means dom0's SRAT may end up advertising a memory
+                 * layout that doesn't match physical placement, which is
+                 * a real degradation, but the alternative (refusing to
+                 * boot dom0 at all) is worse.
+                 */
+                printk(XENLOG_WARNING
+                       "dom0 vNUMA: per-node allocation failed, "
+                       "disabling node binding (SRAT may diverge from "
+                       "actual memory placement)\n");
+                dom0_vnuma_binding_disabled = true;
+                max_order = MAX_ORDER;
+                continue;
+            }
             if ( order == 0 && dom0_memflags )
             {
                 /* Try again without any dom0_memflags. */

--- a/xen/arch/x86/hvm/vlapic.c
+++ b/xen/arch/x86/hvm/vlapic.c
@@ -17,6 +17,7 @@
 #include <xen/lib.h>
 #include <xen/sched.h>
 #include <xen/numa.h>
+#include <asm/cpu-policy.h>
 #include <asm/current.h>
 #include <asm/page.h>
 #include <asm/apic.h>
@@ -1094,7 +1095,7 @@ static uint32_t x2apic_ldr_from_id(uint32_t id)
 static void set_x2apic_id(struct vlapic *vlapic)
 {
     const struct vcpu *v = vlapic_vcpu(vlapic);
-    uint32_t apic_id = v->vcpu_id * 2;
+    uint32_t apic_id = guest_vcpu_x2apic_id(v->domain, v->vcpu_id);
     uint32_t apic_ldr = x2apic_ldr_from_id(apic_id);
 
     /*
@@ -1474,8 +1475,48 @@ void vlapic_reset(struct vlapic *vlapic)
     if ( v->vcpu_id == 0 )
         vlapic->hw.apic_base_msr |= APIC_BASE_BSP;
 
-    vlapic_set_reg(vlapic, APIC_ID, (v->vcpu_id * 2) << 24);
+    vlapic_set_reg(vlapic, APIC_ID,
+                   guest_vcpu_x2apic_id(v->domain, v->vcpu_id) << 24);
     vlapic_do_init(vlapic);
+}
+
+/*
+ * Re-derive a vCPU's APIC ID under the current vNUMA encoding and write it
+ * into the vlapic register state.  Called from arch_domain_update_vnuma()
+ * after a XEN_DOMCTL_setvnumainfo so the value the guest reads from APIC_ID
+ * stays consistent with the CPUID 0xB topology that recalculate_vnuma_topo()
+ * just recomputed.  setvnumainfo is a construction-time operation and runs
+ * before the domain is started; nothing else is observing APIC state.
+ *
+ * For domains using the legacy POT-balanced encoding (or no vNUMA at all),
+ * guest_vcpu_x2apic_id() returns vcpu_id * 2 — identical to what vlapic_init
+ * wrote, so this is a no-op write in the common case.
+ */
+void vlapic_reinit_apic_id(struct vcpu *v)
+{
+    struct vlapic *vlapic = vcpu_vlapic(v);
+    uint32_t apic_id;
+
+    if ( !has_vlapic(v->domain) )
+        return;
+
+    apic_id = guest_vcpu_x2apic_id(v->domain, v->vcpu_id);
+
+    if ( vlapic_x2apic_mode(vlapic) )
+    {
+        uint32_t apic_ldr = x2apic_ldr_from_id(apic_id);
+
+        if ( v->domain->arch.hvm.bug_x2apic_ldr_vcpu_id )
+            apic_ldr = x2apic_ldr_from_id(v->vcpu_id);
+
+        vlapic_set_reg(vlapic, APIC_ID, apic_id);
+        vlapic_set_reg(vlapic, APIC_LDR, apic_ldr);
+    }
+    else
+    {
+        /* xAPIC: APIC ID occupies bits 24..31 of the APIC_ID register. */
+        vlapic_set_reg(vlapic, APIC_ID, apic_id << 24);
+    }
 }
 
 /* rearm the actimer if needed, after a HVM restore */

--- a/xen/arch/x86/include/asm/cpu-policy.h
+++ b/xen/arch/x86/include/asm/cpu-policy.h
@@ -30,4 +30,19 @@ void recalculate_cpuid_policy(struct domain *d);
  */
 void calculate_raw_cpu_policy(void);
 
+/*
+ * Compute the x2APIC identifier assigned to a guest vCPU.  When the domain
+ * has a multi-vnode vNUMA topology and the CPU policy has been patched by
+ * recalculate_vnuma_topo(), the ID encodes (vnode_index, intra_pkg_offset)
+ * so the package boundary in CPUID 0xB falls on a clean bit and APIC IDs do
+ * not collide across packages — including for non-power-of-two and
+ * unbalanced per-vnode vCPU counts.  Otherwise the legacy vcpu_id * 2
+ * encoding is returned.
+ *
+ * All call sites that produce a guest-observable APIC ID (CPUID leaves 0x1
+ * EBX[31:24], 0xB EDX, and vlapic register state) must use this helper so
+ * the guest never observes inconsistent APIC IDs between interfaces.
+ */
+uint32_t guest_vcpu_x2apic_id(const struct domain *d, unsigned int vcpu_id);
+
 #endif /* X86_CPU_POLICY_H */

--- a/xen/arch/x86/include/asm/hvm/vlapic.h
+++ b/xen/arch/x86/include/asm/hvm/vlapic.h
@@ -107,6 +107,14 @@ int vlapic_ack_pending_irq(struct vcpu *v, int vector, bool force_ack);
 int  vlapic_init(struct vcpu *v);
 void vlapic_destroy(struct vcpu *v);
 
+/*
+ * Re-derive a vCPU's APIC ID under the current vNUMA encoding and write it
+ * into the vlapic register state.  Must be called after the toolstack
+ * updates vNUMA topology via XEN_DOMCTL_setvnumainfo so the value the guest
+ * reads from APIC_ID stays consistent with CPUID 0xB.
+ */
+void vlapic_reinit_apic_id(struct vcpu *v);
+
 void vlapic_reset(struct vlapic *vlapic);
 
 int guest_wrmsr_apic_base(struct vcpu *v, uint64_t val);

--- a/xen/arch/x86/include/asm/setup.h
+++ b/xen/arch/x86/include/asm/setup.h
@@ -69,6 +69,8 @@ extern bool opt_dom0_cpuid_faulting;
 extern bool opt_dom0_msr_relaxed;
 extern bool opt_dom0_pvh_auto;
 
+bool dom0_vnuma_enabled(unsigned int max_vcpus);
+
 #define max_init_domid (0)
 
 #endif

--- a/xen/arch/x86/mm.c
+++ b/xen/arch/x86/mm.c
@@ -103,6 +103,7 @@
 #include <xen/lib.h>
 #include <xen/livepatch.h>
 #include <xen/mm.h>
+#include <xen/numa.h>
 #include <xen/param.h>
 #include <xen/perfc.h>
 #include <xen/pfn.h>
@@ -4905,6 +4906,90 @@ long arch_memory_op(unsigned long cmd, XEN_GUEST_HANDLE_PARAM(void) arg)
         break;
     }
 #endif
+
+#ifdef CONFIG_NUMA
+    case XENMEM_get_mfn_pxms:
+    {
+        /*
+         * Resolve a batch of host MFNs to their firmware PXM ids.
+         *
+         * Returned value space is host PXM (matches dom0's SRAT), not
+         * Xen-internal nid.  See xen/include/public/memory.h for the
+         * rationale and the namespace boundary.
+         *
+         * Hardware-domain-only: dom0 backends use this to learn the
+         * physical node hosting a grant-mapped page so they can place
+         * service threads and IRQs accordingly.  No other domain has a
+         * legitimate need for host MFN -> PXM mapping.
+         *
+         * Compiled out without CONFIG_NUMA: a non-NUMA hypervisor has
+         * no meaningful answer, and the dom0-side caller treats the
+         * resulting -ENOSYS as "feature unavailable" and falls back to
+         * the legacy NUMA-oblivious behaviour.
+         */
+        struct xen_get_mfn_pxms req;
+        xen_pfn_t *mfns;
+        uint32_t *pxms;
+        unsigned int i;
+        /*
+         * Cap chosen to bound the kmalloc and the per-call work.  Ring
+         * mappings are typically a handful of pages; 1024 leaves plenty
+         * of headroom and keeps the temporary buffers under 16 KiB.
+         */
+        const unsigned int max_nr = 1024;
+
+        if ( !is_hardware_domain(current->domain) )
+            return -EPERM;
+
+        if ( copy_from_guest(&req, arg, 1) )
+            return -EFAULT;
+
+        if ( req.flags != 0 )
+            return -EINVAL;
+
+        if ( req.nr_mfns == 0 || req.nr_mfns > max_nr )
+            return -EINVAL;
+
+        if ( !guest_handle_okay(req.mfns, req.nr_mfns) ||
+             !guest_handle_okay(req.pxms, req.nr_mfns) )
+            return -EFAULT;
+
+        mfns = xmalloc_array(xen_pfn_t, req.nr_mfns);
+        pxms = xmalloc_array(uint32_t, req.nr_mfns);
+        if ( !mfns || !pxms )
+        {
+            xfree(mfns);
+            xfree(pxms);
+            return -ENOMEM;
+        }
+
+        if ( copy_from_guest(mfns, req.mfns, req.nr_mfns) )
+        {
+            xfree(mfns);
+            xfree(pxms);
+            return -EFAULT;
+        }
+
+        for ( i = 0; i < req.nr_mfns; i++ )
+        {
+            mfn_t mfn = _mfn(mfns[i]);
+
+            if ( mfn_valid(mfn) )
+                pxms[i] = numa_node_to_arch_nid(mfn_to_nid(mfn));
+            else
+                pxms[i] = XEN_INVALID_NUMA_ID;
+        }
+
+        if ( copy_to_guest(req.pxms, pxms, req.nr_mfns) )
+            rc = -EFAULT;
+        else
+            rc = 0;
+
+        xfree(mfns);
+        xfree(pxms);
+        break;
+    }
+#endif /* CONFIG_NUMA */
 
     default:
         return subarch_memory_op(cmd, arg);

--- a/xen/arch/x86/setup.c
+++ b/xen/arch/x86/setup.c
@@ -1006,13 +1006,14 @@ static struct domain *__init create_dom0(struct boot_info *bi)
 {
     char *cmdline = NULL;
     size_t cmdline_size;
+    unsigned int dom0_vcpus = dom0_max_vcpus();
     struct xen_domctl_createdomain dom0_cfg = {
         .flags = IS_ENABLED(CONFIG_TBOOT) ? XEN_DOMCTL_CDF_s3_integrity : 0,
         .max_evtchn_port = -1,
         .max_grant_frames = -1,
         .max_maptrack_frames = -1,
         .grant_opts = XEN_DOMCTL_GRANT_version(opt_gnttab_max_version),
-        .max_vcpus = dom0_max_vcpus(),
+        .max_vcpus = dom0_vcpus,
         .arch = {
             .misc_flags = opt_dom0_msr_relaxed ? XEN_X86_MSR_RELAXED : 0,
         },
@@ -1035,6 +1036,9 @@ static struct domain *__init create_dom0(struct boot_info *bi)
 
     if ( iommu_enabled )
         dom0_cfg.flags |= XEN_DOMCTL_CDF_iommu;
+
+    if ( dom0_vnuma_enabled(dom0_vcpus) )
+        dom0_cfg.flags |= XEN_DOMCTL_CDF_vnuma_apic_topology;
 
     /* Allocate initial domain ID.  Not d0 for pvshim. */
     bd->domid = domid_alloc(get_initial_domain_id());

--- a/xen/common/domain.c
+++ b/xen/common/domain.c
@@ -734,15 +734,24 @@ static int sanitise_domain_config(struct xen_domctl_createdomain *config)
     bool iommu = config->flags & XEN_DOMCTL_CDF_iommu;
     bool vpmu = config->flags & XEN_DOMCTL_CDF_vpmu;
     bool vpci = config->flags & XEN_DOMCTL_CDF_vpci;
+    bool vnuma_apic_topology = config->flags & XEN_DOMCTL_CDF_vnuma_apic_topology;
 
     if ( config->flags &
          ~(XEN_DOMCTL_CDF_hvm | XEN_DOMCTL_CDF_hap |
            XEN_DOMCTL_CDF_s3_integrity | XEN_DOMCTL_CDF_oos_off |
            XEN_DOMCTL_CDF_xs_domain | XEN_DOMCTL_CDF_iommu |
            XEN_DOMCTL_CDF_nested_virt | XEN_DOMCTL_CDF_vpmu |
-           XEN_DOMCTL_CDF_trap_unmapped_accesses | XEN_DOMCTL_CDF_vpci) )
+           XEN_DOMCTL_CDF_trap_unmapped_accesses | XEN_DOMCTL_CDF_vpci |
+           XEN_DOMCTL_CDF_vnuma_apic_topology) )
     {
         dprintk(XENLOG_INFO, "Unknown CDF flags %#x\n", config->flags);
+        return -EINVAL;
+    }
+
+    if ( vnuma_apic_topology && !hvm )
+    {
+        dprintk(XENLOG_INFO,
+                "vNUMA APIC topology encoding requested for non-HVM guest\n");
         return -EINVAL;
     }
 

--- a/xen/common/domctl.c
+++ b/xen/common/domctl.c
@@ -161,9 +161,9 @@ void vnuma_destroy(struct vnuma_info *vnuma)
  * Verifies that single allocation does not exceed
  * PAGE_SIZE.
  */
-static struct vnuma_info *vnuma_alloc(unsigned int nr_vnodes,
-                                      unsigned int nr_ranges,
-                                      unsigned int nr_vcpus)
+struct vnuma_info *vnuma_alloc(unsigned int nr_vnodes,
+                               unsigned int nr_ranges,
+                               unsigned int nr_vcpus)
 {
 
     struct vnuma_info *vnuma;

--- a/xen/common/numa.c
+++ b/xen/common/numa.c
@@ -75,6 +75,32 @@ bool valid_numa_range(paddr_t start, paddr_t end, nodeid_t node)
     return false;
 }
 
+/*
+ * Iterate the (start, end, nid) triples that describe the host's physical
+ * NUMA memory layout.  Used by callers that need to synthesise per-node
+ * memory information for a domain -- e.g. dom0 vNUMA needs to know which
+ * physical node owns each region of its host-shaped guest E820 so the
+ * derived SRAT entries match reality.  Returns false once idx is past the
+ * last memblk.
+ */
+unsigned int numa_get_nr_memblks(void)
+{
+    return num_node_memblks;
+}
+
+bool numa_get_memblk(unsigned int idx, paddr_t *start, paddr_t *end,
+                     nodeid_t *nid)
+{
+    if ( idx >= num_node_memblks )
+        return false;
+
+    *start = node_memblk_range[idx].start;
+    *end = node_memblk_range[idx].end;
+    *nid = memblk_nodeid[idx];
+
+    return true;
+}
+
 static enum conflicts __init conflicting_memblks(
     nodeid_t nid, paddr_t start, paddr_t end, paddr_t nd_start,
     paddr_t nd_end, unsigned int *mblkid)

--- a/xen/include/public/domctl.h
+++ b/xen/include/public/domctl.h
@@ -1038,6 +1038,44 @@ struct xen_domctl_vcpu_msrs {
 };
 #endif
 
+/*
+ * XEN_DOMCTL_get_vcpu_apicids: retrieve the per-vCPU x2APIC identifiers
+ * currently assigned to a domain.
+ *
+ * On x86, when a multi-vnode vNUMA topology has been installed via
+ * XEN_DOMCTL_setvnumainfo, the APIC IDs encode (vnode_index,
+ * intra_pkg_offset) so the package boundary in CPUID 0xB falls on a clean
+ * bit even for non-power-of-two or unbalanced per-vnode vCPU counts.
+ * Without vNUMA (or with a single vnode), APIC IDs follow the legacy
+ * vcpu_id * 2 encoding.
+ *
+ * Toolstacks generating ACPI MADT processor entries for the guest must use
+ * the values returned here to keep the MADT consistent with the values the
+ * guest reads from CPUID 0xB and the vlapic register state.
+ *
+ * Buffer sizing follows the XEN_DOMCTL_get_vcpu_msrs convention:
+ *
+ *   - Pass a NULL apicid_array (or nr_vcpus == 0) for a capacity query;
+ *     no data is copied and nr_filled is set to the domain's max_vcpus.
+ *   - Otherwise nr_vcpus must be >= max_vcpus.  On success the full
+ *     array is written and nr_filled is set to max_vcpus.  If the buffer
+ *     is too small, -ENOBUFS is returned and nr_filled is set to the
+ *     required size so the caller can retry with the right capacity.
+ *
+ * Older Xen builds without this domctl return -ENOSYS, which callers may
+ * use as a capability probe.
+ */
+struct xen_domctl_get_vcpu_apicids {
+    /* IN: output buffer for APIC IDs; entry i is the APIC ID of vCPU i.
+     *     NULL handle = capacity query. */
+    XEN_GUEST_HANDLE_64(uint32) apicid_array;
+    /* IN: capacity of apicid_array in 32-bit elements; 0 = capacity query. */
+    uint32_t nr_vcpus;
+    /* OUT: number of entries written, or max_vcpus for capacity queries
+     *      and -ENOBUFS responses. */
+    uint32_t nr_filled;
+};
+
 /* XEN_DOMCTL_setvnumainfo: specifies a virtual NUMA topology for the guest */
 struct xen_domctl_vnuma {
     /* IN: number of vNUMA nodes to setup. Shall be greater than 0 */
@@ -1388,6 +1426,7 @@ struct xen_domctl {
 #define XEN_DOMCTL_gdbsx_unpausevcpu           1002
 #define XEN_DOMCTL_gdbsx_domstatus             1003
 #define XEN_DOMCTL_vpci_get_devices            2000
+#define XEN_DOMCTL_get_vcpu_apicids            2110
     uint32_t interface_version; /* XEN_DOMCTL_INTERFACE_VERSION */
     domid_t  domain;
     uint16_t _pad[3];
@@ -1453,6 +1492,7 @@ struct xen_domctl {
         struct xen_domctl_set_llc_colors    set_llc_colors;
         struct xen_domctl_get_domain_state  get_domain_state;
         struct xen_domctl_vpci_get_devices  vpci_get_devices;
+        struct xen_domctl_get_vcpu_apicids  get_vcpu_apicids;
         uint8_t                             pad[128];
     } u;
 };

--- a/xen/include/public/domctl.h
+++ b/xen/include/public/domctl.h
@@ -71,8 +71,29 @@ struct xen_domctl_createdomain {
 /* Should vPCI be enabled for the guest? */
 #define XEN_DOMCTL_CDF_vpci           (1U << 9)
 
+/*
+ * Should Xen use vNUMA-derived APIC ID encoding for this domain?
+ *
+ * When unset (default, matches upstream behavior): per-vCPU APIC IDs are
+ * assigned as `vcpu_id * 2`, and recalculate_vnuma_topo() patches CPUID 0xB
+ * only for power-of-two-balanced multi-vnode layouts.  Non-power-of-two or
+ * unbalanced per-vnode vCPU counts silently fall back to default CPUID
+ * topology -- matching how stock Xen has always behaved.
+ *
+ * When set: APIC IDs encode (vnode_index, intra_pkg_offset) so the package
+ * boundary in CPUID 0xB falls on a clean bit even for non-power-of-two or
+ * unbalanced per-vnode vCPU counts.  In return, the toolstack MUST source
+ * MADT processor entries' APIC IDs from XEN_DOMCTL_get_vcpu_apicids rather
+ * than hardcoding `vcpu_id * 2`, since the encoding can produce values that
+ * disagree with that formula.  Failing to do so will produce a MADT
+ * inconsistent with Xen's vlapic state, hanging secondary CPU bringup.
+ *
+ * HVM/PVH only -- rejected for PV at createdomain time.
+ */
+#define XEN_DOMCTL_CDF_vnuma_apic_topology  (1U << 10)
+
 /* Max XEN_DOMCTL_CDF_* constant.  Used for ABI checking. */
-#define XEN_DOMCTL_CDF_MAX XEN_DOMCTL_CDF_vpci
+#define XEN_DOMCTL_CDF_MAX XEN_DOMCTL_CDF_vnuma_apic_topology
 
     uint32_t flags;
 

--- a/xen/include/public/memory.h
+++ b/xen/include/public/memory.h
@@ -740,7 +740,57 @@ struct xen_vnuma_topology_info {
 typedef struct xen_vnuma_topology_info xen_vnuma_topology_info_t;
 DEFINE_XEN_GUEST_HANDLE(xen_vnuma_topology_info_t);
 
-/* Next available subop number is 29 */
+/* Next available upstream subop number is 29.  Edera-custom subops
+ * start at 40 to leave headroom for upstream additions. */
+
+/*
+ * XENMEM_get_mfn_pxms: hardware-domain query that resolves an array of
+ * host MFNs into the host firmware proximity-domain identifier (PXM on
+ * x86 ACPI, the device-tree numa-node-id on systems that use one) of
+ * the node each MFN lives on.
+ *
+ * The result is the firmware-canonical identifier, not Xen's internal
+ * node id.  Three identifier namespaces exist around NUMA:
+ *
+ *   - host PXM         (firmware-supplied, stable, what dom0's SRAT
+ *                       contains and what dom0 Linux maps to its own
+ *                       node ids via pxm_to_node())
+ *   - Xen-internal nid (assigned in SRAT memory-table order; an
+ *                       implementation detail)
+ *   - dom0 Linux node  (Linux-side node id after pxm_to_node())
+ *
+ * Returning PXM lets callers translate to whichever space they need
+ * with a single lookup, and matches what dom0's own SRAT already uses.
+ *
+ * Each output slot is either a valid PXM or XEN_INVALID_NUMA_ID for
+ * MFNs Xen does not have node information for (out of range or
+ * otherwise without a valid frame-table entry).  Hypervisors built
+ * without NUMA support fail the call with -ENOSYS; callers are
+ * expected to treat that as "no NUMA info available" and fall back
+ * to NUMA-oblivious behaviour.
+ *
+ * Callers must be the hardware domain.  nr_mfns is bounded by Xen to
+ * keep the hypercall cost predictable; callers needing more should
+ * batch.
+ */
+#define XENMEM_get_mfn_pxms                 40
+
+#define XEN_INVALID_NUMA_ID                 (~(uint32_t)0)
+
+struct xen_get_mfn_pxms {
+    /* IN: array of host MFNs to look up. */
+    XEN_GUEST_HANDLE(xen_pfn_t) mfns;
+    /* OUT: PXM per MFN, or XEN_INVALID_NUMA_ID. */
+    XEN_GUEST_HANDLE(uint32) pxms;
+    /* IN: length of both arrays. */
+    uint32_t nr_mfns;
+    /* IN: must be zero. */
+    uint32_t flags;
+};
+typedef struct xen_get_mfn_pxms xen_get_mfn_pxms_t;
+DEFINE_XEN_GUEST_HANDLE(xen_get_mfn_pxms_t);
+
+/* Next available Edera-custom subop number is 41 */
 
 #endif /* __XEN_PUBLIC_MEMORY_H__ */
 

--- a/xen/include/xen/domain.h
+++ b/xen/include/xen/domain.h
@@ -190,9 +190,19 @@ struct vnuma_info {
 
 #ifndef CONFIG_PV_SHIM_EXCLUSIVE
 void vnuma_destroy(struct vnuma_info *vnuma);
+struct vnuma_info *vnuma_alloc(unsigned int nr_vnodes,
+                               unsigned int nr_ranges,
+                               unsigned int nr_vcpus);
 #else
 static inline void vnuma_destroy(struct vnuma_info *vnuma) { ASSERT(!vnuma); }
 #endif
+
+/*
+ * Notify the architecture layer that the domain's vNUMA topology has
+ * changed.  On x86 this recalculates CPUID topology leaves that depend
+ * on vNUMA configuration.  Weak no-op default in common/domctl.c.
+ */
+void arch_domain_update_vnuma(struct domain *d);
 
 extern bool vmtrace_available;
 

--- a/xen/include/xen/numa.h
+++ b/xen/include/xen/numa.h
@@ -123,6 +123,18 @@ static inline nodeid_t mfn_to_nid(mfn_t mfn)
 extern int arch_get_ram_range(unsigned int idx,
                               paddr_t *start, paddr_t *end);
 extern bool valid_numa_range(paddr_t start, paddr_t end, nodeid_t node);
+
+/*
+ * Iterators over the host's physical NUMA memory blocks (the [start, end)
+ * ranges fed in via SRAT / device tree, one per arch-node).  numa_get_memblk
+ * returns false once idx >= numa_get_nr_memblks().  Intended for callers
+ * that need to synthesise per-node memory affinity for guest-visible
+ * tables (e.g. dom0 vNUMA SRAT generation).
+ */
+extern unsigned int numa_get_nr_memblks(void);
+extern bool numa_get_memblk(unsigned int idx, paddr_t *start, paddr_t *end,
+                            nodeid_t *nid);
+
 extern bool numa_memblks_available(void);
 extern bool numa_update_node_memblks(nodeid_t node, unsigned int arch_nid,
                                      paddr_t start, paddr_t size, bool hotplug);

--- a/xen/xsm/flask/hooks.c
+++ b/xen/xsm/flask/hooks.c
@@ -750,6 +750,7 @@ static int cf_check flask_domctl(struct domain *d, unsigned int cmd,
         return current_has_perm(d, SECCLASS_DOMAIN, DOMAIN__SETVCPUCONTEXT);
 
     case XEN_DOMCTL_get_ext_vcpucontext:
+    case XEN_DOMCTL_get_vcpu_apicids:
     case XEN_DOMCTL_get_vcpu_msrs:
     case XEN_DOMCTL_getvcpucontext:
     case XEN_DOMCTL_getvcpuextstate:


### PR DESCRIPTION
The non-power-of-two vCPU count CPUID patching is controlled via an opt-in domain creation flag, `XEN_DOMCTL_CDF_vnuma_apic_topology`. Because that patching will modify APIC IDs to match the topology, the toolstack will be required to set MADT to match the Xen-assigned APIC IDs retrieved via `XEN_DOMCTL_get_vcpu_apicids`. This change is a dependency for NPOT support in https://github.com/edera-dev/protect/pull/2569

Additionally, we now give PVH dom0s a real vNUMA configuration when booted with `dom0_vcpus_pin=1`. 