### PR TITLE
implement low-level HVM forking for AMD guests

### DIFF
--- a/xen/arch/x86/hvm/svm/intr.c
+++ b/xen/arch/x86/hvm/svm/intr.c
@@ -133,6 +133,12 @@ void asmlinkage svm_intr_assist(void)
     if ( unlikely(v->arch.vm_event) && v->arch.vm_event->sync_event )
         return;
 
+#ifdef CONFIG_MEM_SHARING
+    /* Block event injection for VM fork if requested */
+    if ( unlikely(v->domain->arch.hvm.mem_sharing.block_interrupts) )
+        return;
+#endif
+
     /* Crank the handle on interrupt state. */
     pt_update_irq(v);
 

--- a/xen/arch/x86/hvm/svm/svm.c
+++ b/xen/arch/x86/hvm/svm/svm.c
@@ -2423,6 +2423,28 @@ static void cf_check svm_set_reg(struct vcpu *v, unsigned int reg, uint64_t val)
     }
 }
 
+static void cf_check svm_get_nonreg_state(struct vcpu *v,
+    struct hvm_vcpu_nonreg_state *nrs)
+{
+    const struct vmcb_struct *vmcb = v->arch.hvm.svm.vmcb;
+
+    nrs->svm.intr_shadow = vmcb->int_stat.intr_shadow;
+    nrs->svm.vintr = vmcb_get_vintr(vmcb).bytes;
+}
+
+static void cf_check svm_set_nonreg_state(struct vcpu *v,
+    struct hvm_vcpu_nonreg_state *nrs)
+{
+    struct vmcb_struct *vmcb = v->arch.hvm.svm.vmcb;
+    vintr_t intr;
+
+    vmcb->int_stat.intr_shadow = nrs->svm.intr_shadow;
+
+    /* vmcb_set_vintr() clears the vintr clean bit for us. */
+    intr.bytes = nrs->svm.vintr;
+    vmcb_set_vintr(vmcb, intr);
+}
+
 static struct hvm_function_table __initdata_cf_clobber svm_function_table = {
     .name                 = "SVM",
     .cpu_up_prepare       = svm_cpu_up_prepare,
@@ -2473,6 +2495,9 @@ static struct hvm_function_table __initdata_cf_clobber svm_function_table = {
 
     .get_reg = svm_get_reg,
     .set_reg = svm_set_reg,
+
+    .get_nonreg_state = svm_get_nonreg_state,
+    .set_nonreg_state = svm_set_nonreg_state,
 
     .tsc_scaling = {
         .max_ratio = ~TSC_RATIO_RSVD_BITS,

--- a/xen/arch/x86/include/asm/hvm/hvm.h
+++ b/xen/arch/x86/include/asm/hvm/hvm.h
@@ -90,6 +90,10 @@ struct hvm_vcpu_nonreg_state {
             uint64_t pending_dbg;
             uint64_t interrupt_status;
         } vmx;
+        struct {
+            bool     intr_shadow;
+            uint64_t vintr;
+        } svm;
     };
 };
 

--- a/xen/arch/x86/mm/mem_sharing.c
+++ b/xen/arch/x86/mm/mem_sharing.c
@@ -1506,7 +1506,7 @@ static inline int mem_sharing_control(struct domain *d, bool enable,
 {
     if ( enable )
     {
-        if ( unlikely(!is_hvm_domain(d) || !cpu_has_vmx) )
+        if ( unlikely(!is_hvm_domain(d) || (!cpu_has_vmx && !cpu_has_svm)) )
             return -EOPNOTSUPP;
 
         if ( unlikely(!hap_enabled(d)) )


### PR DESCRIPTION
HVM (and thus PVH) guests have had a forking interface largely intended for fuzzing the hypervisor, but it can be used for forking warm VMs as well (with some limitations).

Unfortunately, the forking interface was only functional on Intel platforms, this patch series extends the support to AMD platforms.