### PR TITLE
fix(ocaml): unbreak build-time assertion of CDF flag max

### DIFF
--- a/tools/ocaml/libs/xc/xenctrl.ml
+++ b/tools/ocaml/libs/xc/xenctrl.ml
@@ -71,6 +71,7 @@ type domain_create_flag =
   | CDF_VPMU
   | CDF_TRAP_UNMAPPED_ACCESSES
   | CDF_VPCI
+  | CDF_VNUMA_APIC_TOPOLOGY
 
 type domain_create_iommu_opts =
   | IOMMU_NO_SHAREPT

--- a/tools/ocaml/libs/xc/xenctrl.mli
+++ b/tools/ocaml/libs/xc/xenctrl.mli
@@ -64,6 +64,7 @@ type domain_create_flag =
   | CDF_VPMU
   | CDF_TRAP_UNMAPPED_ACCESSES
   | CDF_VPCI
+  | CDF_VNUMA_APIC_TOPOLOGY
 
 type domain_create_iommu_opts =
   | IOMMU_NO_SHAREPT


### PR DESCRIPTION
Fixes failed assertion:

    BUILD_BUG_ON( XEN_DOMCTL_CDF_MAX             != (1u << 9)  );