### PR TITLE
x86/hyperv: answer the reference counter MSR for a nested PV dom0

### DIFF
--- a/xen/arch/x86/guest/hyperv/hyperv.c
+++ b/xen/arch/x86/guest/hyperv/hyperv.c
@@ -115,7 +115,8 @@ void cpuid_hyperv_passthrough_leaves(const struct vcpu *v, uint32_t leaf,
          * support lands (see the VMBus enablement milestones).
          */
         res->a = HV_X64_MSR_HYPERCALL_AVAILABLE |
-                 HV_X64_MSR_VP_INDEX_AVAILABLE;
+                 HV_X64_MSR_VP_INDEX_AVAILABLE |
+                 (ms_hyperv.features & HV_MSR_TIME_REF_COUNT_AVAILABLE);
         break;
 
     case 5: /* Implementation limits -- report the underlying L0 host's. */

--- a/xen/arch/x86/guest/hyperv/passthrough.c
+++ b/xen/arch/x86/guest/hyperv/passthrough.c
@@ -386,6 +386,26 @@ int guest_rdmsr_hyperv_pt(const struct vcpu *v, uint32_t idx, uint64_t *val)
         *val = v->vcpu_id;
         break;
 
+    case HV_X64_MSR_TIME_REF_COUNT:
+        /*
+         * The partition reference counter is read-only L0 state counting in
+         * 100ns units, so simply forward the host's value.
+         *
+         * This matters even though the guest does not use the Hyper-V
+         * clocksource: a Xen PV dom0 never runs ms_hyperv_init_platform(), so
+         * hv_init_clocksource() does not either, and Linux keeps the default
+         * hv_read_reference_counter() -- which reads exactly this MSR.  The
+         * Hyper-V TimeSync driver interpolates the host's time samples
+         * against that counter, so failing the read leaves /dev/ptp_hyperv
+         * reporting a frozen host time and any NTP client that steps to it
+         * (chrony's default Azure configuration polls the PHC refclock every
+         * 8s with "makestep 1.0 -1") walks the wall clock backwards forever.
+         */
+        if ( !(ms_hyperv.features & HV_MSR_TIME_REF_COUNT_AVAILABLE) )
+            return X86EMUL_EXCEPTION;
+        rdmsrl(HV_X64_MSR_TIME_REF_COUNT, *val);
+        break;
+
     case HV_X64_MSR_VP_ASSIST_PAGE:
         *val = vp->vp_assist_msr;
         break;


### PR DESCRIPTION
A Xen PV dom0 reads HV_X64_MSR_TIME_REF_COUNT even though it makes no use of the Hyper-V clocksource.  Linux overrides
hv_read_reference_counter() only in hv_init_clocksource(), reached solely from ms_hyperv_init_platform(), which does not run when the detected hypervisor is Xen; dom0 therefore keeps the default implementation, a plain read of this MSR.

The proxy did not answer it, so the read took a #GP and the counter came back as zero.  Hyper-V's TimeSync integration service interpolates the host's periodic time samples against that counter, and with it frozen /dev/ptp_hyperv reports whatever the host last said, never advancing between samples.  An NTP client disciplining the clock from that PHC refclock - chrony's stock Azure configuration polls it every eight seconds and may step at any offset above a second - then walks the wall clock backwards on every poll.  The guest's own stale-sample check cannot catch it, as the interval it tests is derived from the same counter and so is always zero.

Forward the host's value: the counter is read-only partition state counting in 100ns units, needing neither translation nor per-domain state, and Xen may read it directly as the L0 guest.  Advertise it in the feature leaf now that it is answered.