### PR TITLE
fix(ci): add @alexandermerritt to the 4.22 xen codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kaniini @azenla @bleggett @tycho
+* @kaniini @azenla @bleggett @tycho @alexandermerritt


### PR DESCRIPTION
Already did this on the 4.21 branch, but since this was cut before that and it's a separate branch, it has its own CODEOWNERS so we have to do it twice.